### PR TITLE
Hotfix - setConfigVars postMessage Reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "lodash.merge": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/lib/setConfigVars.ts
+++ b/src/lib/setConfigVars.ts
@@ -1,3 +1,4 @@
+import { postMessage } from "../utils/postMessage";
 import {
   ConnectionConfigVarInput,
   DefaultConfigVarInput,


### PR DESCRIPTION
`setConfigVars` is referencing the incorrect `postMessage` method, should be using the custom postMessage instead of the window.postMessage.
