### PR TITLE
Translation - FilterBar Refresh Button & Tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "lodash.merge": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/phrases.ts
+++ b/src/types/phrases.ts
@@ -165,6 +165,12 @@ interface SharedPhrases {
   /** English: "Clear filters" */
   "filterBar.clearFiltersButton": SimplePhrase;
 
+  /** English: "Refresh" */
+  "filterBar.refreshButton": SimplePhrase;
+
+  /** English: "Auto-polling is only available with default filters." */
+  "filterBar.refreshTooltip": SimplePhrase;
+
   /** English: "[Empty String]" */
   "filterBar.title": SimplePhrase;
 
@@ -634,12 +640,6 @@ export interface UniquePhrases {
 
   /** English: "To add logs, make sure your instance is running." */
   "integrations.id.logs__filterResults.placeholderText--hasInstance": SimplePhrase;
-
-  /** English: "Refresh logs" */
-  "integrations.id.logs__filterBar.refreshButton": SimplePhrase;
-
-  /** English: "Polling is only available with default filters." */
-  "integrations.id.logs__filterBar.refreshTooltip": SimplePhrase;
 
   // marketplace not found
   /** English: "Not Found" */


### PR DESCRIPTION
Make `filterBar.refreshButton` and `filterBar.refreshTooltip` generalized, instead of name-spaced. This allows us to use these in different screens of the application. Since these are name-spaced, they will work if the user had previously opted to setting these translations. 