### PR TITLE
Types - Export Additional Interfaces, Enums, Types.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "lodash.merge": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,17 +18,7 @@ export {
   getMessageIframe,
 } from "./utils/postMessage";
 
-export {
-  ConfigVar,
-  ConnectionConfigVar,
-  ConnectionConfigVarInput,
-  DefaultConfigVar,
-  DefaultConfigVarInput,
-} from "./types/configVars";
-
-export { ScreenConfiguration } from "./types/screenConfiguration";
-
-export { Translation } from "./types/translation";
+export * from "./types";
 
 export default {
   authenticate,

--- a/src/lib/authenticate.ts
+++ b/src/lib/authenticate.ts
@@ -15,20 +15,20 @@ export interface AuthenticateProps {
   token: string;
 }
 
-export const authenticate = async (props: AuthenticateProps) => {
+export const authenticate = async (options: AuthenticateProps) => {
   assertInit("authenticate");
 
-  if (!props) {
+  if (!options) {
     throw new Error(ERROR_MESSAGE);
   }
 
-  const givenProps = new Set(Object.keys(props));
+  const givenProps = new Set(Object.keys(options));
 
   if (!EXPECTED_KEYS.every((key) => givenProps.has(key))) {
     throw new Error(ERROR_MESSAGE);
   }
 
-  const { token } = props;
+  const { token } = options;
 
   const iframeElement = document.getElementById(
     EMBEDDED_IFRAME_ID
@@ -46,7 +46,7 @@ export const authenticate = async (props: AuthenticateProps) => {
 
   state.jwt = token;
 
-  const prismaticUrl = props.prismaticUrl ?? state.prismaticUrl;
+  const prismaticUrl = options.prismaticUrl ?? state.prismaticUrl;
 
   const authResponse = await fetch(
     urlJoin(prismaticUrl, "embedded", "authenticate"),

--- a/src/lib/configureInstance.ts
+++ b/src/lib/configureInstance.ts
@@ -2,7 +2,7 @@ import { Options } from "../types/options";
 import { assertInit } from "../utils/assertInit";
 import { setIframe } from "../utils/iframe";
 
-type ConfigureInstanceProps = Options & {
+export type ConfigureInstanceProps = Options & {
   integrationName: string;
   skipRedirectOnRemove?: boolean;
 };

--- a/src/lib/graphqlRequest.ts
+++ b/src/lib/graphqlRequest.ts
@@ -3,7 +3,7 @@ import urlJoin from "url-join";
 import { state } from "../state";
 import { assertInit } from "../utils/assertInit";
 
-export interface graphqlRequestProps {
+export interface GraphqlRequestProps {
   query: string;
   variables?: Record<string, unknown>;
 }
@@ -11,7 +11,7 @@ export interface graphqlRequestProps {
 export const graphqlRequest = async ({
   query,
   variables,
-}: graphqlRequestProps) => {
+}: GraphqlRequestProps) => {
   assertInit("authenticate");
 
   const { jwt: accessToken, prismaticUrl } = state;

--- a/src/lib/setConfigVars.ts
+++ b/src/lib/setConfigVars.ts
@@ -20,9 +20,12 @@ export type SetConfigVarsProps =
   | IFrameSetConfigVarProps
   | SelectorSetConfigVarProps;
 
-export const setConfigVars = ({ configVars, ...props }: SetConfigVarsProps) => {
+export const setConfigVars = ({
+  configVars,
+  ...options
+}: SetConfigVarsProps) => {
   postMessage({
-    ...props,
+    ...options,
     event: { event: "SET_CONFIG_VAR", data: configVars },
   });
 };

--- a/src/lib/showComponent.ts
+++ b/src/lib/showComponent.ts
@@ -2,7 +2,7 @@ import { Options } from "../types/options";
 import { assertInit } from "../utils/assertInit";
 import { setIframe } from "../utils/iframe";
 
-type ShowComponentProps = Options & {
+export type ShowComponentProps = Options & {
   componentId: string;
 };
 

--- a/src/lib/showComponents.ts
+++ b/src/lib/showComponents.ts
@@ -2,7 +2,7 @@ import { Options } from "../types/options";
 import { assertInit } from "../utils/assertInit";
 import { setIframe } from "../utils/iframe";
 
-type ShowComponentsProps = Options & {};
+export type ShowComponentsProps = Options & {};
 
 export const showComponents = (options: ShowComponentsProps) => {
   assertInit("showComponents");

--- a/src/lib/showDesigner.ts
+++ b/src/lib/showDesigner.ts
@@ -2,7 +2,7 @@ import { Options } from "../types/options";
 import { assertInit } from "../utils/assertInit";
 import { setIframe } from "../utils/iframe";
 
-type ShowDesignerProps = Options & {
+export type ShowDesignerProps = Options & {
   integrationId: string;
 };
 

--- a/src/lib/showIntegrations.ts
+++ b/src/lib/showIntegrations.ts
@@ -2,7 +2,7 @@ import { Options } from "../types/options";
 import { assertInit } from "../utils/assertInit";
 import { setIframe } from "../utils/iframe";
 
-type ShowIntegrationsProps = Options & {};
+export type ShowIntegrationsProps = Options & {};
 
 export const showIntegrations = (options: ShowIntegrationsProps) => {
   assertInit("showIntegrations");

--- a/src/lib/showLogs.ts
+++ b/src/lib/showLogs.ts
@@ -2,7 +2,7 @@ import { Options } from "../types/options";
 import { assertInit } from "../utils/assertInit";
 import { setIframe } from "../utils/iframe";
 
-type ShowLogsProps = Options & {};
+export type ShowLogsProps = Options & {};
 
 export const showLogs = (options: ShowLogsProps) => {
   assertInit("showLogs");

--- a/src/lib/showMarketplace.ts
+++ b/src/lib/showMarketplace.ts
@@ -2,7 +2,7 @@ import { Options } from "../types/options";
 import { assertInit } from "../utils/assertInit";
 import { setIframe } from "../utils/iframe";
 
-type ShowMarketplaceProps = Options & {};
+export type ShowMarketplaceProps = Options & {};
 
 export const showMarketplace = (options: ShowMarketplaceProps) => {
   assertInit("showMarketplace");

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,3 +24,25 @@ export {
   ScreenConfiguration,
   TriggerDetails,
 } from "./screenConfiguration";
+
+export { InitProps } from "../lib/init";
+
+export { ShowMarketplaceProps } from "../lib/showMarketplace";
+
+export { ShowLogsProps } from "../lib/showLogs";
+
+export { ShowIntegrationsProps } from "../lib/showIntegrations";
+
+export { ShowDesignerProps } from "../lib/showDesigner";
+
+export { ShowComponentsProps } from "../lib/showComponents";
+
+export { ShowComponentProps } from "../lib/showComponent";
+
+export { SetConfigVarsProps } from "../lib/setConfigVars";
+
+export { GraphqlRequestProps } from "../lib/graphqlRequest";
+
+export { ConfigureInstanceProps } from "../lib/configureInstance";
+
+export { AuthenticateProps } from "../lib/authenticate";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,26 @@
+export { Phrases } from "./phrases";
+
+export { Translation } from "./translation";
+
+export { SelectorOptions, PopoverOptions, Options } from "./options";
+
+export { Filters } from "./filters";
+
+export { Theme } from "./theme";
+
+export {
+  ConfigVar,
+  ConnectionConfigVar,
+  ConnectionConfigVarInput,
+  DefaultConfigVar,
+  DefaultConfigVarInput,
+} from "./configVars";
+
+export {
+  ConfigurationWizardConfiguration,
+  InitializingConfiguration,
+  InstanceScreenConfiguration,
+  MarketplaceConfiguration,
+  ScreenConfiguration,
+  TriggerDetails,
+} from "./screenConfiguration";

--- a/src/types/screenConfiguration.ts
+++ b/src/types/screenConfiguration.ts
@@ -1,24 +1,24 @@
-type TriggerDetails = "default" | "default-open" | "hidden";
+export type TriggerDetails = "default" | "default-open" | "hidden";
 
-interface InstanceScreenConfiguration {
+export interface InstanceScreenConfiguration {
   hideBackToMarketplace?: boolean;
   hideTabs?: Array<"Test" | "Executions" | "Monitors" | "Logs">;
 }
 
-interface MarketplaceConfiguration {
+export interface MarketplaceConfiguration {
   configuration: "allow-details" | "always-show-details" | "disallow-details";
   /** Include all active Integrations including those activated outside the Marketplace. */
   includeActiveIntegrations?: boolean;
 }
 
-interface InitializingConfiguration {
+export interface InitializingConfiguration {
   /** The background color of the loading screen */
   background: string;
   /** The font color of the loading screen text and loading icon */
   color: string;
 }
 
-interface ConfigurationWizardConfiguration {
+export interface ConfigurationWizardConfiguration {
   hideSidebar?: boolean;
   isInModal?: boolean;
   triggerDetailsConfiguration?: TriggerDetails;


### PR DESCRIPTION
Add additional exported types to package for users consumption. Requested here #5, below are the types added:

- Phrases
- Translation
- SelectorOptions
- PopoverOptions
- Options
- Filters
- Theme
- ConfigVar
- ConnectionConfigVar
- ConnectionConfigVarInput
- DefaultConfigVar
- DefaultConfigVarInput
- ConfigurationWizardConfiguration
- InitializingConfiguration
- InstanceScreenConfiguration
- MarketplaceConfiguration
- ScreenConfiguration
- TriggerDetails
- InitProps
- ShowMarketplaceProps
- ShowLogsProps
- ShowIntegrationsProps
- ShowDesignerProps
- ShowComponentsProps
- ShowComponentProps
- SetConfigVarsProps
- GraphqlRequestProps
- ConfigureInstanceProps
- AuthenticateProps
