### PR TITLE
Hotfix - Global Rewrite for Browser Envs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "lodash.merge": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const package = require("./package.json");
 
 module.exports = {
   mode: "production",
-  target: "node",
+  node: { global: true },
   module: {
     rules: [
       {


### PR DESCRIPTION
> The problem is, I think, this target: 'node' in your webpack.config.js. This states basically that Webpack may assume that the bundle will be running in a node-like environment, where globals like global and require are provided by the environment. Unless otherwise specified, Webpack assumes a browser environment and rewrites global to point to window. Your configuration disables this rewriting. 
>
> You could either remove target: 'node' from your config, or explicitly enable global rewriting by adding node: {global: true} to your config object.