### PR TITLE
Fix initialization of embedded state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "7.6.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -18,16 +18,16 @@ export interface InitProps
 export const init = (options?: InitProps) => {
   const existingElement = document.getElementById(EMBEDDED_ID);
 
-  if (existingElement) {
-    return;
-  }
-
   if (options) {
     Object.entries(options).forEach(([key, value]) => {
       if (key in state) {
         state[key] = value;
       }
     });
+  }
+
+  if (existingElement) {
+    return;
   }
 
   state.initComplete = true;

--- a/src/utils/iframe.ts
+++ b/src/utils/iframe.ts
@@ -76,17 +76,66 @@ export const setIframe = (
   }
 
   iframeContainerElement.innerHTML = /* html */ `
-    <iframe 
+    <iframe
       id="${EMBEDDED_IFRAME_ID}"
-      src="${state.prismaticUrl}/${route}/?${queryParams.toString()}" 
-      height="100%" 
-      width="100%" 
+      src="${state.prismaticUrl}/${route}/?${queryParams.toString()}"
+      height="100%"
+      width="100%"
       frameBorder="0"
       allow="clipboard-read; clipboard-write"
     ></iframe>
   `;
 
   const iframeElement = iframeContainerElement.querySelector("iframe");
+
+  if (iframeElement) {
+    window.addEventListener(
+      "message",
+      (event: MessageEvent<{ event: string }>) => {
+        if (event.data?.event === "PRISMATIC_INITIALIZED") {
+          postMessage({
+            iframe: iframeElement,
+            event: {
+              event: PrismaticMessageEvent.SET_TOKEN,
+              data: state.jwt,
+            },
+          });
+
+          postMessage({
+            iframe: iframeElement,
+            event: {
+              event: PrismaticMessageEvent.SET_VERSION,
+              data: EMBEDDED_VERSION,
+            },
+          });
+
+          postMessage({
+            iframe: iframeElement,
+            event: {
+              event: PrismaticMessageEvent.SET_TRANSLATION,
+              data: state.translation,
+            },
+          });
+
+          postMessage({
+            iframe: iframeElement,
+            event: {
+              event: PrismaticMessageEvent.SET_SCREEN_CONFIGURATION,
+              data: state.screenConfiguration,
+            },
+          });
+
+          postMessage({
+            iframe: iframeElement,
+            event: {
+              event: PrismaticMessageEvent.SET_FILTERS,
+              data: state.filters,
+            },
+          });
+        }
+      }
+    );
+  }
 
   if (iframeElement && options?.autoFocusIframe !== false) {
     iframeElement.addEventListener("mouseenter", () => {
@@ -96,60 +145,5 @@ export const setIframe = (
 
   if (isPopover(options)) {
     openPopover();
-  }
-
-  if (iframeElement) {
-    iframeElement.onload = () => {
-      // TODO: JC - This is redundant for the fact that the JWT is still being passed as a query param. We'll eventually do this refactor to avoid passing the JWT as a query param. Reference https://github.com/prismatic-io/prismatic/pull/5324
-      if (state.jwt) {
-        postMessage({
-          iframe: iframeElement,
-          event: {
-            event: PrismaticMessageEvent.SET_TOKEN,
-            data: state.jwt,
-          },
-        });
-      }
-
-      if (EMBEDDED_VERSION) {
-        postMessage({
-          iframe: iframeElement,
-          event: {
-            event: PrismaticMessageEvent.SET_VERSION,
-            data: EMBEDDED_VERSION,
-          },
-        });
-      }
-
-      if (state.translation) {
-        postMessage({
-          iframe: iframeElement,
-          event: {
-            event: PrismaticMessageEvent.SET_TRANSLATION,
-            data: state.translation,
-          },
-        });
-      }
-
-      if (state.screenConfiguration) {
-        postMessage({
-          iframe: iframeElement,
-          event: {
-            event: PrismaticMessageEvent.SET_SCREEN_CONFIGURATION,
-            data: state.screenConfiguration,
-          },
-        });
-      }
-
-      if (state.filters) {
-        postMessage({
-          iframe: iframeElement,
-          event: {
-            event: PrismaticMessageEvent.SET_FILTERS,
-            data: state.filters,
-          },
-        });
-      }
-    };
   }
 };


### PR DESCRIPTION
`iframe.onload` guaranteed that the iframe existed in the DOM however the React app was never hydrated prior to sending events over. Embedded now waits until the React app sends an initialized event before sending it's initial configuration.

This also assures that subsequent calls to prismatic.init update the configuration