### PR TITLE
Add filters to embedded SDK for integrations, marketplace, and components

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,1 @@
-github-cli 2.20.2
 nodejs 18.16.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-github-cli 2.30.0
+github-cli 2.20.2
 nodejs 18.16.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "7.6.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,7 +4,7 @@ export { authenticate } from "./authenticate";
 export {
   configureInstance,
   /**
-   * @deprecated Use configureInstance instead
+   * @deprecated Use configureInstance instead, this will be removed in the next major version (v2.0.0)
    */
   configureInstance as configureIntegration, // alias for backwards compatibility
 };

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -1,3 +1,5 @@
+import merge from "lodash.merge";
+
 import { styles } from "../styles";
 import { closePopover } from "../utils/popover";
 import { state, State } from "../state";
@@ -10,13 +12,30 @@ import {
   EMBEDDED_POPOVER_CLASS,
   EMBEDDED_POPOVER_CLOSE_CLASS,
 } from "../utils/iframe";
+import { showMarketplaceDefaults } from "./showMarketplace";
 
 export interface InitProps
   extends Pick<State, "screenConfiguration" | "theme" | "translation">,
     Partial<Pick<State, "filters" | "prismaticUrl">> {}
 
-export const init = (options?: InitProps) => {
+const optionsDefault = {
+  filters: {
+    ...showMarketplaceDefaults["filters"],
+    integrations: {},
+    components: {},
+  },
+  screenConfiguration: {
+    ...showMarketplaceDefaults["screenConfiguration"],
+    initializing: {},
+  },
+  theme: {},
+  translation: {},
+};
+
+export const init = (optionsBase?: InitProps) => {
   const existingElement = document.getElementById(EMBEDDED_ID);
+
+  const options: InitProps = merge({}, optionsDefault, optionsBase);
 
   if (options) {
     Object.entries(options).forEach(([key, value]) => {

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -12,7 +12,6 @@ import {
   EMBEDDED_POPOVER_CLASS,
   EMBEDDED_POPOVER_CLOSE_CLASS,
 } from "../utils/iframe";
-import { showMarketplaceDefaults } from "./showMarketplace";
 
 export interface InitProps
   extends Pick<State, "screenConfiguration" | "theme" | "translation">,
@@ -20,12 +19,16 @@ export interface InitProps
 
 const optionsDefault = {
   filters: {
-    ...showMarketplaceDefaults["filters"],
+    marketplace: {
+      includeActiveIntegrations: true,
+    },
     integrations: {},
     components: {},
   },
   screenConfiguration: {
-    ...showMarketplaceDefaults["screenConfiguration"],
+    configurationWizard: {},
+    instance: {},
+    marketplace: {},
     initializing: {},
   },
   theme: {},

--- a/src/lib/showMarketplace.ts
+++ b/src/lib/showMarketplace.ts
@@ -1,6 +1,36 @@
+import {
+  ConfigurationWizardConfiguration,
+  InstanceScreenConfiguration,
+  MarketplaceConfiguration,
+  MarketplaceFilters,
+} from "../types";
 import { Options } from "../types/options";
 import { assertInit } from "../utils/assertInit";
 import { setIframe } from "../utils/iframe";
+
+interface ShowMarketplaceDefaults {
+  filters: {
+    marketplace: MarketplaceFilters;
+  };
+  screenConfiguration: {
+    configurationWizard: ConfigurationWizardConfiguration;
+    instance: InstanceScreenConfiguration;
+    marketplace: MarketplaceConfiguration;
+  };
+}
+
+export const showMarketplaceDefaults: ShowMarketplaceDefaults = {
+  filters: {
+    marketplace: {
+      includeActiveIntegrations: true,
+    },
+  },
+  screenConfiguration: {
+    configurationWizard: {},
+    instance: {},
+    marketplace: {},
+  },
+};
 
 export type ShowMarketplaceProps = Options & {};
 
@@ -9,18 +39,5 @@ export const showMarketplace = (
 ) => {
   assertInit("showMarketplace");
 
-  setIframe(
-    "integration-marketplace",
-    {
-      ...options,
-      screenConfiguration: {
-        ...(options?.screenConfiguration ?? {}),
-        marketplace: {
-          includeActiveIntegrations: true,
-          ...(options?.screenConfiguration?.marketplace ?? {}),
-        },
-      },
-    },
-    {}
-  );
+  setIframe("integration-marketplace", options, {});
 };

--- a/src/lib/showMarketplace.ts
+++ b/src/lib/showMarketplace.ts
@@ -1,36 +1,6 @@
-import {
-  ConfigurationWizardConfiguration,
-  InstanceScreenConfiguration,
-  MarketplaceConfiguration,
-  MarketplaceFilters,
-} from "../types";
 import { Options } from "../types/options";
 import { assertInit } from "../utils/assertInit";
 import { setIframe } from "../utils/iframe";
-
-interface ShowMarketplaceDefaults {
-  filters: {
-    marketplace: MarketplaceFilters;
-  };
-  screenConfiguration: {
-    configurationWizard: ConfigurationWizardConfiguration;
-    instance: InstanceScreenConfiguration;
-    marketplace: MarketplaceConfiguration;
-  };
-}
-
-export const showMarketplaceDefaults: ShowMarketplaceDefaults = {
-  filters: {
-    marketplace: {
-      includeActiveIntegrations: true,
-    },
-  },
-  screenConfiguration: {
-    configurationWizard: {},
-    instance: {},
-    marketplace: {},
-  },
-};
 
 export type ShowMarketplaceProps = Options & {};
 

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -39,15 +39,15 @@ export interface IntegrationsFilters {
 
 export type Filters = {
   /**
-   * @deprecated Use marketplace instead
+   * @deprecated Use marketplace instead, this will be removed in the next major version (v2.0.0)
    */
   category?: string;
   /**
-   * @deprecated Use marketplace instead
+   * @deprecated Use marketplace instead, this will be removed in the next major version (v2.0.0)
    */
   filterQuery?: ConditionalExpression;
   /**
-   * @deprecated Use marketplace instead
+   * @deprecated Use marketplace instead, this will be removed in the next major version (v2.0.0)
    */
   label?: string;
   components?: ComponentsFilters;

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -19,8 +19,38 @@ const {
 
 export { BooleanOperator, TermOperator, ConditionalExpression };
 
-export type Filters = {
+export interface MarketplaceFilters {
+  category?: string;
+  filterQuery?: ConditionalExpression;
+  includeActiveIntegrations?: boolean;
+  label?: string;
+}
+
+export interface ComponentsFilters {
   category?: string;
   filterQuery?: ConditionalExpression;
   label?: string;
+}
+
+export interface IntegrationsFilters {
+  category?: string;
+  label?: string;
+}
+
+export type Filters = {
+  /**
+   * @deprecated Use marketplace instead
+   */
+  category?: string;
+  /**
+   * @deprecated Use marketplace instead
+   */
+  filterQuery?: ConditionalExpression;
+  /**
+   * @deprecated Use marketplace instead
+   */
+  label?: string;
+  components?: ComponentsFilters;
+  integrations?: IntegrationsFilters;
+  marketplace?: MarketplaceFilters;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,8 +6,11 @@ export { SelectorOptions, PopoverOptions, Options } from "./options";
 
 export {
   BooleanOperator,
+  ComponentsFilters,
   ConditionalExpression,
   Filters,
+  IntegrationsFilters,
+  MarketplaceFilters,
   TermOperator,
 } from "./filters";
 

--- a/src/types/screenConfiguration.ts
+++ b/src/types/screenConfiguration.ts
@@ -10,7 +10,7 @@ export interface MarketplaceConfiguration {
   /**
    * Include all active Integrations including those activated outside the Marketplace.
    * @default true
-   * @deprecated Use marketplace filter instead
+   * @deprecated Use marketplace filters instead, this will be removed in the next major version (v2.0.0)
    */
   includeActiveIntegrations?: boolean;
 }

--- a/src/types/screenConfiguration.ts
+++ b/src/types/screenConfiguration.ts
@@ -10,6 +10,7 @@ export interface MarketplaceConfiguration {
   /**
    * Include all active Integrations including those activated outside the Marketplace.
    * @default true
+   * @deprecated Use marketplace filter instead
    */
   includeActiveIntegrations?: boolean;
 }


### PR DESCRIPTION
Add filters to embedded SDK for integrations, marketplace, and components

- moved includeActiveIntegrations from screen configurations to filters
- added integrations filters
- added components filters
- added marketplace filters (deprecated main level filters)
- added a new way to defaults (since methods have a bug that will always overwrite the init options)