### PR TITLE
Bump @prismatic-io/embedded to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "1.7.2",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "1.7.2",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "7.6.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "1.7.2",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
Starting in the `2.0.0` release of `@prismatic-io/embedded`, the default value for `screenConfiguration.marketplace.configuration` changes from `always-show-details` to `allow-details`.  To keep existing behavior, explicitly set the configuration value to `always-show-details`.

https://prismatic.io/docs/embedding-marketplace/#integration-configuration-detail-screen