### PR TITLE
Fix subsequent calls to embedded methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "7.6.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/lib/authenticate.ts
+++ b/src/lib/authenticate.ts
@@ -4,7 +4,7 @@ import { PrismaticMessageEvent } from "../types/postMessage";
 import { EMBEDDED_IFRAME_ID } from "../utils/iframe";
 import { assertInit } from "../utils/assertInit";
 import { postMessage } from "../utils/postMessage";
-import { state } from "../state";
+import { getCurrentState, setCurrentState } from "../state";
 
 const ERROR_MESSAGE =
   "The authenticate method expects an object containing a token and additional optional configuration.";
@@ -34,6 +34,7 @@ export const authenticate = async (options: AuthenticateProps) => {
     EMBEDDED_IFRAME_ID
   ) as HTMLIFrameElement;
 
+  const state = getCurrentState();
   if (state.jwt !== token && iframeElement) {
     postMessage({
       iframe: iframeElement,
@@ -45,6 +46,8 @@ export const authenticate = async (options: AuthenticateProps) => {
   }
 
   state.jwt = token;
+
+  setCurrentState(state);
 
   const prismaticUrl = options.prismaticUrl ?? state.prismaticUrl;
 

--- a/src/lib/authenticate.ts
+++ b/src/lib/authenticate.ts
@@ -4,7 +4,7 @@ import { PrismaticMessageEvent } from "../types/postMessage";
 import { EMBEDDED_IFRAME_ID } from "../utils/iframe";
 import { assertInit } from "../utils/assertInit";
 import { postMessage } from "../utils/postMessage";
-import { getCurrentState, setCurrentState } from "../state";
+import stateService from "../state";
 
 const ERROR_MESSAGE =
   "The authenticate method expects an object containing a token and additional optional configuration.";
@@ -34,7 +34,7 @@ export const authenticate = async (options: AuthenticateProps) => {
     EMBEDDED_IFRAME_ID
   ) as HTMLIFrameElement;
 
-  const state = getCurrentState();
+  const state = stateService.getStateCopy();
   if (state.jwt !== token && iframeElement) {
     postMessage({
       iframe: iframeElement,
@@ -47,7 +47,7 @@ export const authenticate = async (options: AuthenticateProps) => {
 
   state.jwt = token;
 
-  setCurrentState(state);
+  stateService.setState(state);
 
   const prismaticUrl = options.prismaticUrl ?? state.prismaticUrl;
 

--- a/src/lib/graphqlRequest.ts
+++ b/src/lib/graphqlRequest.ts
@@ -1,6 +1,6 @@
 import urlJoin from "url-join";
 
-import { getCurrentState } from "../state";
+import stateService from "../state";
 import { assertInit } from "../utils/assertInit";
 
 export interface GraphqlRequestProps {
@@ -14,7 +14,7 @@ export const graphqlRequest = async ({
 }: GraphqlRequestProps) => {
   assertInit("authenticate");
 
-  const { jwt: accessToken, prismaticUrl } = getCurrentState();
+  const { jwt: accessToken, prismaticUrl } = stateService.getStateCopy();
 
   const response = await fetch(urlJoin(prismaticUrl, "api"), {
     method: "POST",

--- a/src/lib/graphqlRequest.ts
+++ b/src/lib/graphqlRequest.ts
@@ -1,6 +1,6 @@
 import urlJoin from "url-join";
 
-import { state } from "../state";
+import { getCurrentState } from "../state";
 import { assertInit } from "../utils/assertInit";
 
 export interface GraphqlRequestProps {
@@ -14,7 +14,7 @@ export const graphqlRequest = async ({
 }: GraphqlRequestProps) => {
   assertInit("authenticate");
 
-  const { jwt: accessToken, prismaticUrl } = state;
+  const { jwt: accessToken, prismaticUrl } = getCurrentState();
 
   const response = await fetch(urlJoin(prismaticUrl, "api"), {
     method: "POST",

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -2,7 +2,7 @@ import merge from "lodash.merge";
 
 import { styles } from "../styles";
 import { closePopover } from "../utils/popover";
-import { state, State } from "../state";
+import { setCurrentState, State, getCopyOfDefaultState } from "../state";
 import {
   EMBEDDED_ID,
   EMBEDDED_IFRAME_CONTAINER_CLASS,
@@ -40,12 +40,17 @@ export const init = (optionsBase?: InitProps) => {
 
   const options: InitProps = merge({}, optionsDefault, optionsBase);
 
+  // when we initialize, start from the fresh default state
+  const state = getCopyOfDefaultState();
+
   if (options) {
     Object.entries(options).forEach(([key, value]) => {
       if (key in state) {
         state[key] = value;
       }
     });
+
+    setCurrentState(state);
   }
 
   if (existingElement) {
@@ -53,6 +58,8 @@ export const init = (optionsBase?: InitProps) => {
   }
 
   state.initComplete = true;
+
+  setCurrentState(state);
 
   document.head.insertAdjacentHTML("beforeend", styles);
 

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -2,7 +2,7 @@ import merge from "lodash.merge";
 
 import { styles } from "../styles";
 import { closePopover } from "../utils/popover";
-import { setCurrentState, State, getCopyOfDefaultState } from "../state";
+import stateService, { State } from "../state";
 import {
   EMBEDDED_ID,
   EMBEDDED_IFRAME_CONTAINER_CLASS,
@@ -41,7 +41,7 @@ export const init = (optionsBase?: InitProps) => {
   const options: InitProps = merge({}, optionsDefault, optionsBase);
 
   // when we initialize, start from the fresh default state
-  const state = getCopyOfDefaultState();
+  const state = stateService.getInitialState();
 
   if (options) {
     Object.entries(options).forEach(([key, value]) => {
@@ -50,7 +50,7 @@ export const init = (optionsBase?: InitProps) => {
       }
     });
 
-    setCurrentState(state);
+    stateService.setState(state);
   }
 
   if (existingElement) {
@@ -59,7 +59,7 @@ export const init = (optionsBase?: InitProps) => {
 
   state.initComplete = true;
 
-  setCurrentState(state);
+  stateService.setState(state);
 
   document.head.insertAdjacentHTML("beforeend", styles);
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -27,20 +27,36 @@ const defaultState: State = {
   translation: undefined,
 };
 
-let state: State | null = null;
+class StateService {
+  private defaultState: State;
+  private state: State | null = null;
 
-export const getCopyOfDefaultState = (): State => structuredClone(defaultState);
+  constructor(defaultState: State) {
+    this.defaultState = defaultState;
+  }
 
-export const getCopyOfState = (): State =>
-  structuredClone(state ?? defaultState);
+  getInitialState() {
+    return JSON.parse(JSON.stringify(this.defaultState));
+  }
 
-export const getCurrentState = (): State => {
-  // if we do not have a cached state then return a copy of the default state so that it can be safely mutated
-  if (!state) return getCopyOfDefaultState();
+  /**
+   * A function that returns a copy of the current state.  If a mutation is desired, you must call
+   * `stateService.setState` afterwards to persist the updated copy.
+   * @returns A deep copy of the state to prevent accidental mutations.
+   */
+  getStateCopy() {
+    if (this.state) {
+      return JSON.parse(JSON.stringify(this.state));
+    }
 
-  return state;
-};
+    return this.getInitialState();
+  }
 
-export const setCurrentState = (newState: State): void => {
-  state = newState;
-};
+  setState(state: State) {
+    this.state = state;
+  }
+}
+
+const stateService = new StateService(defaultState);
+
+export default stateService;

--- a/src/state.ts
+++ b/src/state.ts
@@ -13,7 +13,7 @@ export interface State {
   translation?: Translation;
 }
 
-export const state: State = {
+const defaultState: State = {
   filters: {
     category: undefined,
     filterQuery: undefined,
@@ -25,4 +25,22 @@ export const state: State = {
   screenConfiguration: undefined,
   theme: undefined,
   translation: undefined,
+};
+
+let state: State | null = null;
+
+export const getCopyOfDefaultState = (): State => structuredClone(defaultState);
+
+export const getCopyOfState = (): State =>
+  structuredClone(state ?? defaultState);
+
+export const getCurrentState = (): State => {
+  // if we do not have a cached state then return a copy of the default state so that it can be safely mutated
+  if (!state) return getCopyOfDefaultState();
+
+  return state;
+};
+
+export const setCurrentState = (newState: State): void => {
+  state = newState;
 };

--- a/src/utils/assertInit.ts
+++ b/src/utils/assertInit.ts
@@ -1,7 +1,7 @@
-import { state } from "../state";
+import { getCurrentState } from "../state";
 
 export const assertInit = (functionName: string) => {
-  if (!state.initComplete) {
+  if (!getCurrentState().initComplete) {
     throw new Error(
       `Expected init to be called before calling ${functionName}`
     );

--- a/src/utils/assertInit.ts
+++ b/src/utils/assertInit.ts
@@ -1,7 +1,7 @@
-import { getCurrentState } from "../state";
+import stateService from "../state";
 
 export const assertInit = (functionName: string) => {
-  if (!getCurrentState().initComplete) {
+  if (!stateService.getStateCopy().initComplete) {
     throw new Error(
       `Expected init to be called before calling ${functionName}`
     );

--- a/src/utils/iframe.ts
+++ b/src/utils/iframe.ts
@@ -4,7 +4,7 @@ import { PrismaticMessageEvent } from "../types/postMessage";
 import { isPopover, Options } from "../types/options";
 import { openPopover } from "./popover";
 import { postMessage } from "./postMessage";
-import { state } from "../state";
+import { getCopyOfState } from "../state";
 
 export const EMBEDDED_ID = "pio__embedded";
 export const EMBEDDED_IFRAME_ID = "pio__iframe";
@@ -45,6 +45,9 @@ export const setIframe = (
   if (!iframeContainerElement) {
     return;
   }
+
+  // we use a copy of state so that changes to this only impact this iframe and do not update the shared state
+  const state = getCopyOfState();
 
   if (options) {
     Object.entries(options).forEach(([key, value]) => {

--- a/src/utils/iframe.ts
+++ b/src/utils/iframe.ts
@@ -4,7 +4,7 @@ import { PrismaticMessageEvent } from "../types/postMessage";
 import { isPopover, Options } from "../types/options";
 import { openPopover } from "./popover";
 import { postMessage } from "./postMessage";
-import { getCopyOfState } from "../state";
+import stateService from "../state";
 
 export const EMBEDDED_ID = "pio__embedded";
 export const EMBEDDED_IFRAME_ID = "pio__iframe";
@@ -47,7 +47,7 @@ export const setIframe = (
   }
 
   // we use a copy of state so that changes to this only impact this iframe and do not update the shared state
-  const state = getCopyOfState();
+  const state = stateService.getStateCopy();
 
   if (options) {
     Object.entries(options).forEach(([key, value]) => {


### PR DESCRIPTION
Updates the references to the shared state so that calls to `prismatic.init` will always start from the fresh default state, and calls to `setIframe` do not mutate the shared state but simply pass the merged state to the iframe.