### PR TITLE
Use url-join to generate iframe src properties, to account for trailing slashes

### DIFF
--- a/src/utils/iframe.ts
+++ b/src/utils/iframe.ts
@@ -5,6 +5,7 @@ import { isPopover, Options } from "../types/options";
 import { openPopover } from "./popover";
 import { postMessage } from "./postMessage";
 import stateService, { ValidKeys } from "../state";
+import urlJoin from "url-join";
 
 export const EMBEDDED_ID = "pio__embedded";
 export const EMBEDDED_IFRAME_ID = "pio__iframe";
@@ -84,10 +85,12 @@ export const setIframe = (
     );
   }
 
+  const iframeSrc = urlJoin(state.prismaticUrl, route, `?${queryParams}`);
+
   iframeContainerElement.innerHTML = /* html */ `
     <iframe
       id="${EMBEDDED_IFRAME_ID}"
-      src="${state.prismaticUrl}/${route}/?${queryParams.toString()}"
+      src="${iframeSrc}"
       height="100%"
       width="100%"
       frameBorder="0"


### PR DESCRIPTION
If you initialize the Prismatic embedded SDK with a URL that has a trailing slash (i.e. `https://app.ap-southeast-2.prismatic.io/` vs `https://app.ap-southeast-2.prismatic.io`), an `iframe` is built with double-slashes (i.e. `https://app.ap-southeast-2.prismatic.io//integration-marketplace?embed=....`). The double-slashes result in a 404.

Rather than using string concatenation for iframe `src` property, let's use `url-join`, which handles trailing slashes for you.