### PR TITLE
Add support for custom google fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "7.6.1",
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@types/node": "18.11.18",
+        "@types/webfontloader": "^1.6.35",
         "prettier": "2.8.3",
         "ts-loader": "9.4.2",
         "typescript": "4.9.5",
@@ -227,6 +228,12 @@
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+    },
+    "node_modules/@types/webfontloader": {
+      "version": "1.6.35",
+      "resolved": "https://registry.npmjs.org/@types/webfontloader/-/webfontloader-1.6.35.tgz",
+      "integrity": "sha512-IJlrsiDWq6KghQ7tPlL5tcwSUyOxLDceT+AFUY7Ylj0Fcv3/h3QkANqQxZ0B5mEpEKxhTw76vDmvrruSMV9n9Q==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "16.0.5",
@@ -2261,6 +2268,12 @@
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+    },
+    "@types/webfontloader": {
+      "version": "1.6.35",
+      "resolved": "https://registry.npmjs.org/@types/webfontloader/-/webfontloader-1.6.35.tgz",
+      "integrity": "sha512-IJlrsiDWq6KghQ7tPlL5tcwSUyOxLDceT+AFUY7Ylj0Fcv3/h3QkANqQxZ0B5mEpEKxhTw76vDmvrruSMV9n9Q==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "16.0.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@types/node": "18.11.18",
+    "@types/webfontloader": "^1.6.35",
     "prettier": "2.8.3",
     "ts-loader": "9.4.2",
     "typescript": "4.9.5",
@@ -41,8 +42,8 @@
     "webpack-cli": "5.0.1"
   },
   "dependencies": {
-    "@prismatic-io/translations": "latest",
     "@prismatic-io/spectral": "7.6.1",
+    "@prismatic-io/translations": "latest",
     "lodash.merge": "4.6.2",
     "url-join": "5.0.0"
   }

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -14,7 +14,10 @@ import {
 } from "../utils/iframe";
 
 export interface InitProps
-  extends Pick<State, "screenConfiguration" | "theme" | "translation">,
+  extends Pick<
+      State,
+      "screenConfiguration" | "theme" | "fontConfiguration" | "translation"
+    >,
     Partial<Pick<State, "filters" | "prismaticUrl">> {}
 
 const optionsDefault = {
@@ -32,6 +35,7 @@ const optionsDefault = {
     initializing: {},
   },
   theme: "LIGHT",
+  fontConfiguration: undefined,
   translation: {},
 };
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -2,6 +2,7 @@ import { Filters } from "./types/filters";
 import { ScreenConfiguration } from "./types/screenConfiguration";
 import { Theme } from "./types/theme";
 import { Translation } from "./types/translation";
+import WebFont from "webfontloader";
 
 export interface State {
   filters: Filters;
@@ -10,6 +11,7 @@ export interface State {
   prismaticUrl: string;
   screenConfiguration?: ScreenConfiguration;
   theme?: Theme;
+  fontConfiguration?: Pick<WebFont.Config, "google">;
   translation?: Translation;
 }
 
@@ -24,6 +26,7 @@ const defaultState: State = {
   prismaticUrl: "https://app.prismatic.io",
   screenConfiguration: undefined,
   theme: undefined,
+  fontConfiguration: undefined,
   translation: undefined,
 };
 
@@ -39,7 +42,7 @@ class StateService {
     this.defaultState = defaultState;
   }
 
-  getInitialState() {
+  getInitialState(): State {
     return JSON.parse(JSON.stringify(this.defaultState));
   }
 
@@ -48,7 +51,7 @@ class StateService {
    * `stateService.setState` afterwards to persist the updated copy.
    * @returns A deep copy of the state to prevent accidental mutations.
    */
-  getStateCopy() {
+  getStateCopy(): State {
     if (this.state) {
       return JSON.parse(JSON.stringify(this.state));
     }

--- a/src/utils/iframe.ts
+++ b/src/utils/iframe.ts
@@ -77,6 +77,12 @@ export const setIframe = (
       JSON.stringify(state.screenConfiguration.initializing)
     );
   }
+  if (state.fontConfiguration) {
+    queryParams.set(
+      "fontConfiguration",
+      JSON.stringify(state.fontConfiguration)
+    );
+  }
 
   iframeContainerElement.innerHTML = /* html */ `
     <iframe


### PR DESCRIPTION
This uses [WebFontLoader](https://github.com/typekit/webfontloader) to load custom Google fonts for use in embedded

Example usage:

```ts
prismatic.init({
  fontConfiguration: {
    google: {
      families: ["Inter"],
    },
  },
});
```