### PR TITLE
Add ability to configure disabling logs and step results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "7.6.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/screenConfiguration.ts
+++ b/src/types/screenConfiguration.ts
@@ -26,6 +26,16 @@ export interface ConfigurationWizardConfiguration {
   hideSidebar?: boolean;
   isInModal?: boolean;
   triggerDetailsConfiguration?: TriggerDetails;
+  /**
+   * Disable logs on integrations deployed via marketplace
+   * @default "never"
+   */
+  logsDisabled?: "always" | "never" | "optional";
+  /**
+   * Disable step results on integrations deployed via marketplace
+   * @default "never"
+   */
+  stepResultsDisabled?: "always" | "never" | "optional";
 }
 
 export interface DashboardScreenConfiguration {


### PR DESCRIPTION
Adds the following properties to `ScreenConfiguration["configurationWizard"]` for disabling logs and step results for integration deployed through embedded.

```ts
  /**
   * Disable logs on integrations deployed via marketplace
   * @default "never"
   */
  logsDisabled?: "always" | "never" | "optional";
  /**
   * Disable step results on integrations deployed via marketplace
   * @default "never"
   */
  stepResultsDisabled?: "always" | "never" | "optional";
```