### PR TITLE
Add strictMatchFilterQuery and bump to v2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "7.6.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -9,7 +9,7 @@ export {
   configureInstance as configureIntegration, // alias for backwards compatibility
 };
 export { graphqlRequest } from "./graphqlRequest";
-export { init } from "./init";
+export { init, EMBEDDED_DEFAULTS } from "./init";
 export { setConfigVars } from "./setConfigVars";
 export { showComponent } from "./showComponent";
 export { showComponents } from "./showComponents";

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -20,7 +20,7 @@ export interface InitProps
     >,
     Partial<Pick<State, "filters" | "prismaticUrl">> {}
 
-const optionsDefault = {
+export const EMBEDDED_DEFAULTS = {
   filters: {
     marketplace: {
       includeActiveIntegrations: true,
@@ -42,7 +42,7 @@ const optionsDefault = {
 export const init = (optionsBase?: InitProps) => {
   const existingElement = document.getElementById(EMBEDDED_ID);
 
-  const options: InitProps = merge({}, optionsDefault, optionsBase);
+  const options: InitProps = merge({}, EMBEDDED_DEFAULTS, optionsBase);
 
   // when we initialize, start from the fresh default state
   const state = stateService.getInitialState();

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -24,6 +24,7 @@ export interface MarketplaceFilters {
   filterQuery?: ConditionalExpression;
   includeActiveIntegrations?: boolean;
   label?: string;
+  strictMatchFilterQuery?: boolean;
 }
 
 export interface ComponentsFilters {


### PR DESCRIPTION
Add strictMatchFilterQuery to allow embedded developers to prioritize includeActiveIntegrations over filters.