### PR TITLE
Expose ConfigVars Type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "7.6.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/lib/setConfigVars.ts
+++ b/src/lib/setConfigVars.ts
@@ -1,12 +1,9 @@
+import { ConfigVars } from "../types/configVars";
 import { PrismaticMessageEvent } from "../types/postMessage";
 import { postMessage } from "../utils/postMessage";
-import {
-  ConnectionConfigVarInput,
-  DefaultConfigVarInput,
-} from "../types/configVars";
 
 interface SetConfigVarsPropsBase {
-  configVars: Record<string, DefaultConfigVarInput | ConnectionConfigVarInput>;
+  configVars: ConfigVars;
 }
 
 interface SelectorSetConfigVarProps extends SetConfigVarsPropsBase {

--- a/src/types/configVars.ts
+++ b/src/types/configVars.ts
@@ -57,6 +57,11 @@ export interface ConnectionConfigVar {
 
 export type ConfigVar = DefaultConfigVar | ConnectionConfigVar;
 
+export type ConfigVars = Record<
+  string,
+  DefaultConfigVarInput | ConnectionConfigVarInput
+>;
+
 interface BaseConfigVarInput {
   value: string;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,7 @@ export { Theme } from "./theme";
 
 export {
   ConfigVar,
+  ConfigVars,
   ConnectionConfigVar,
   ConnectionConfigVarInput,
   DefaultConfigVar,


### PR DESCRIPTION
Our setConfigVars method's main property is configVars. This property is used in several different places within the application, and it may also be accessed by external users. Exposing this property allows us to avoid using type indexes or repeating type aliases when using or creating the config variables for setConfigVars method.