### PR TITLE
Expose closePopover() function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "7.6.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ export * from "./types";
 
 export * from "./lib";
 
+export { closePopover } from "./utils/popover";
+
 export default {
   ...methods,
 };

--- a/src/utils/popover.ts
+++ b/src/utils/popover.ts
@@ -13,6 +13,10 @@ export const getPopover = () =>
 export const openPopover = () =>
   getPopover()?.classList.add(EMBEDDED_OVERLAY_VISIBLE_CLASS);
 
+/**
+ * Closes an open popover
+ * @returns void
+ */
 export const closePopover = () => {
   const iframeElement = getIframeContainerElement(
     `${EMBEDDED_IFRAME_CONTAINER_SELECTOR} > iframe`


### PR DESCRIPTION
Under certain circumstances, it is helpful to be able to close an open popover from an application that embeds Prismatic. This exposes the `closePopover()` function.