### PR TITLE
Adds Hide Search Check for Dynamic Phrases & Hides ActiveIntegrationsFilter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "2.4.2",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "7.9.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -45,7 +45,7 @@ export const init = (optionsBase?: InitProps) => {
   // tmp fix to hide search bar to avoid confusion when dynamic phrases are provided
   const options: InitProps = merge({}, EMBEDDED_DEFAULTS, {
     ...optionsBase,
-    screenConfiruation: {
+    screenConfiguration: {
       ...optionsBase?.screenConfiguration,
       marketplace: {
         ...optionsBase?.screenConfiguration?.marketplace,

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -42,7 +42,17 @@ export const EMBEDDED_DEFAULTS = {
 export const init = (optionsBase?: InitProps) => {
   const existingElement = document.getElementById(EMBEDDED_ID);
 
-  const options: InitProps = merge({}, EMBEDDED_DEFAULTS, optionsBase);
+  // tmp fix to hide search bar to avoid confusion when dynamic phrases are provided
+  const options: InitProps = merge({}, EMBEDDED_DEFAULTS, {
+    ...optionsBase,
+    screenConfiruation: {
+      ...optionsBase?.screenConfiguration,
+      marketplace: {
+        ...optionsBase?.screenConfiguration?.marketplace,
+        hideSearch: optionsBase?.translation?.phrases ? true : false,
+      },
+    },
+  });
 
   // when we initialize, start from the fresh default state
   const state = stateService.getInitialState();

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -42,17 +42,7 @@ export const EMBEDDED_DEFAULTS = {
 export const init = (optionsBase?: InitProps) => {
   const existingElement = document.getElementById(EMBEDDED_ID);
 
-  // tmp fix to hide search bar to avoid confusion when dynamic phrases are provided
-  const options: InitProps = merge({}, EMBEDDED_DEFAULTS, {
-    ...optionsBase,
-    screenConfiguration: {
-      ...optionsBase?.screenConfiguration,
-      marketplace: {
-        ...optionsBase?.screenConfiguration?.marketplace,
-        hideSearch: optionsBase?.translation?.phrases ? true : false,
-      },
-    },
-  });
+  const options: InitProps = merge({}, EMBEDDED_DEFAULTS, optionsBase);
 
   // when we initialize, start from the fresh default state
   const state = stateService.getInitialState();

--- a/src/types/screenConfiguration.ts
+++ b/src/types/screenConfiguration.ts
@@ -14,6 +14,7 @@ export interface MarketplaceConfiguration {
    */
   includeActiveIntegrations?: boolean;
   hideSearch?: boolean;
+  hideActiveIntegrationsFilter?: boolean;
 }
 
 export interface InitializingConfiguration {

--- a/src/types/screenConfiguration.ts
+++ b/src/types/screenConfiguration.ts
@@ -13,6 +13,7 @@ export interface MarketplaceConfiguration {
    * @deprecated Use marketplace filters instead, this will be removed in the next major version (v3.0.0)
    */
   includeActiveIntegrations?: boolean;
+  hideSearch?: boolean;
 }
 
 export interface InitializingConfiguration {


### PR DESCRIPTION
https://app.shortcut.com/prismatic/story/18009/add-ability-to-hide-search-inputs-from-embeddable-screens-due-to-translation-searching-difficiencies