### PR TITLE
Bump @prismatic-io/translations dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "7.9.0",
-        "@prismatic-io/translations": "1.10.0",
+        "@prismatic-io/translations": "1.11.3",
         "lodash.merge": "4.6.2",
         "url-join": "5.0.0"
       },
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/@prismatic-io/translations": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@prismatic-io/translations/-/translations-1.10.0.tgz",
-      "integrity": "sha512-8qKSocyeYvFQJrz5v50ouBS9i5GoJaP6fk/weKMYF+EkMq4+diSwzYqUTPAFf1PKauvtQ6P8RMzCbWcCtSydnQ=="
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@prismatic-io/translations/-/translations-1.11.3.tgz",
+      "integrity": "sha512-cPZLYJ6lzZNieQWvVMtRDDGK+7F5GFfdfNuWI5Rg/NiX3H7lwIkBaoFPFG8rDvjRCL5bK76ejmT0mCNB42abQA=="
     },
     "node_modules/@types/eslint": {
       "version": "8.21.0",
@@ -2001,9 +2001,9 @@
       }
     },
     "@prismatic-io/translations": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@prismatic-io/translations/-/translations-1.10.0.tgz",
-      "integrity": "sha512-8qKSocyeYvFQJrz5v50ouBS9i5GoJaP6fk/weKMYF+EkMq4+diSwzYqUTPAFf1PKauvtQ6P8RMzCbWcCtSydnQ=="
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@prismatic-io/translations/-/translations-1.11.3.tgz",
+      "integrity": "sha512-cPZLYJ6lzZNieQWvVMtRDDGK+7F5GFfdfNuWI5Rg/NiX3H7lwIkBaoFPFG8rDvjRCL5bK76ejmT0mCNB42abQA=="
     },
     "@types/eslint": {
       "version": "8.21.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@prismatic-io/spectral": "7.9.0",
-    "@prismatic-io/translations": "1.10.0",
+    "@prismatic-io/translations": "1.11.3",
     "lodash.merge": "4.6.2",
     "url-join": "5.0.0"
   }


### PR DESCRIPTION
This updates the `@prismatic-io/translations` to its latest version to allow for dynamic translations of integration names, config variables, and more.