### PR TITLE
Throw an error if showMarketplace() or similar functions are called before a successful authenticate()

### DIFF
--- a/src/lib/authenticate.ts
+++ b/src/lib/authenticate.ts
@@ -5,6 +5,7 @@ import { EMBEDDED_IFRAME_ID } from "../utils/iframe";
 import { assertInit } from "../utils/assertInit";
 import { postMessage } from "../utils/postMessage";
 import stateService from "../state";
+import { graphqlRequest } from "./graphqlRequest";
 
 const ERROR_MESSAGE =
   "The authenticate method expects an object containing a token and additional optional configuration.";
@@ -72,5 +73,18 @@ export const authenticate = async (options: AuthenticateProps) => {
 
   state.jwt = token;
 
+  stateService.setState(state);
+
+  const result = await graphqlRequest({
+    query: `{
+      authenticatedUser {
+        customer {
+          allowEmbeddedDesigner
+        }
+      }
+    }`,
+  });
+  state.embeddedDesignerEnabled =
+    result.data.authenticatedUser.customer.allowEmbeddedDesigner;
   stateService.setState(state);
 };

--- a/src/lib/authenticate.ts
+++ b/src/lib/authenticate.ts
@@ -45,10 +45,6 @@ export const authenticate = async (options: AuthenticateProps) => {
     });
   }
 
-  state.jwt = token;
-
-  stateService.setState(state);
-
   const prismaticUrl = options.prismaticUrl ?? state.prismaticUrl;
 
   const authResponse = await fetch(
@@ -73,4 +69,8 @@ export const authenticate = async (options: AuthenticateProps) => {
       );
     }
   }
+
+  state.jwt = token;
+
+  stateService.setState(state);
 };

--- a/src/lib/showDesigner.ts
+++ b/src/lib/showDesigner.ts
@@ -1,4 +1,5 @@
 import { Options } from "../types/options";
+import { assertEmbeddedDesigner } from "../utils/assertEmbeddedDesigner";
 import { assertInit } from "../utils/assertInit";
 import { setIframe } from "../utils/iframe";
 
@@ -11,6 +12,7 @@ export const showDesigner = ({
   ...options
 }: ShowDesignerProps) => {
   assertInit("showDesigner");
+  assertEmbeddedDesigner("showDesigner");
 
   setIframe(`/integrations/${integrationId}/`, options, {});
 };

--- a/src/lib/showIntegrations.ts
+++ b/src/lib/showIntegrations.ts
@@ -1,4 +1,5 @@
 import { Options } from "../types/options";
+import { assertEmbeddedDesigner } from "../utils/assertEmbeddedDesigner";
 import { assertInit } from "../utils/assertInit";
 import { setIframe } from "../utils/iframe";
 
@@ -6,6 +7,7 @@ export type ShowIntegrationsProps = Options & {};
 
 export const showIntegrations = (options: ShowIntegrationsProps) => {
   assertInit("showIntegrations");
+  assertEmbeddedDesigner("showIntegrations");
 
   setIframe("/integrations/", options, {});
 };

--- a/src/state.ts
+++ b/src/state.ts
@@ -8,6 +8,7 @@ export interface State {
   filters: Filters;
   initComplete: boolean;
   jwt: string;
+  embeddedDesignerEnabled: boolean;
   prismaticUrl: string;
   screenConfiguration?: ScreenConfiguration;
   theme?: Theme;
@@ -23,6 +24,7 @@ const defaultState: State = {
   },
   initComplete: false,
   jwt: "",
+  embeddedDesignerEnabled: false,
   prismaticUrl: "https://app.prismatic.io",
   screenConfiguration: undefined,
   theme: undefined,

--- a/src/utils/assertEmbeddedDesigner.ts
+++ b/src/utils/assertEmbeddedDesigner.ts
@@ -1,0 +1,9 @@
+import stateService from "../state";
+
+export const assertEmbeddedDesigner = (functionName: string) => {
+  if (!stateService.getStateCopy().embeddedDesignerEnabled) {
+    throw new Error(
+      `Embedded designer must be enabled for this customer in order to call ${functionName}`
+    );
+  }
+};

--- a/src/utils/assertInit.ts
+++ b/src/utils/assertInit.ts
@@ -6,4 +6,10 @@ export const assertInit = (functionName: string) => {
       `Expected init to be called before calling ${functionName}`
     );
   }
+
+  if (!stateService.getStateCopy().jwt && functionName !== "authenticate") {
+    throw new Error(
+      `Expected authenticate to be called before calling ${functionName}`
+    );
+  }
 };


### PR DESCRIPTION
Currently, if you omit a `prismatic.authenticate()` call, or if your call fails but is not caught, a `showMarketplace()` or similar call will still inject an `iframe` but the iframe will contain a 404 screen. This makes it so a successful `prismatic.authenticate()` call must run before subsequent calls are allowed, and an instructive error is thrown if you attempt to call `showMarketplace()` prior to `authenticate()`.