### PR TITLE
Add an example showing how to display components as custom UI elements

### DIFF
--- a/example-embedded-app/pages/examples/custom-component-list.md
+++ b/example-embedded-app/pages/examples/custom-component-list.md
@@ -1,0 +1,11 @@
+## Custom Component List
+
+This page demonstrates how you can fetch a list of all available components from the [Prismatic GraphQL API](https://prismatic.io/docs/embedded-api-requests/) and render the components with custom UI elements.
+
+GraphQL queries and mutations are run using the `prismatic.graphqlRequest()` function.
+You can test out GraphQL queries from the Prismatic [GraphQL explorer](https://prismatic.io/docs/explorer/).
+
+This page runs a `components` query on behalf of your customer user, and maps the array of component objects that are returned to custom UI objects.
+This is handy if you would like to display a list of components that your customer has access to in the embedded designer.
+
+You can edit this page by modifying `pages/examples/custom-component-list.tsx`.

--- a/example-embedded-app/pages/examples/custom-component-list.tsx
+++ b/example-embedded-app/pages/examples/custom-component-list.tsx
@@ -1,0 +1,180 @@
+import Head from "next/head";
+
+import prismatic from "@prismatic-io/embedded";
+
+import React, { useEffect } from "react";
+import SidebarLayout from "@/layouts/SidebarLayout";
+import ExampleHeader from "@/components/ExampleHeader";
+import PageTitleWrapper from "@/components/PageTitleWrapper";
+import Footer from "@/components/Footer";
+import usePrismaticAuth from "@/usePrismaticAuth";
+import {
+  Avatar,
+  Card,
+  CardContent,
+  CardHeader,
+  Container,
+  Grid,
+  LinearProgress,
+  Typography,
+} from "@mui/material";
+
+import config from "prismatic/config";
+
+import customComponentListHelperText from "./custom-component-list.md";
+
+interface Component {
+  id: string;
+  versionNumber: number;
+  label: string;
+  description: string;
+  iconUrl: string;
+  public: boolean;
+}
+
+/**
+ * This component is used to display the avatar for a marketplace integration.
+ * Icons are used if the integration does not have an avatar.
+ * Images are fetched from a presigned S3 URL.
+ */
+function PrismaticAvatar({ avatarUrl, token }) {
+  const [src, setSrc] = React.useState("");
+
+  useEffect(() => {
+    let mounted = true;
+    if (avatarUrl) {
+      fetch(`${config.prismaticUrl}${avatarUrl}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }).then((response) => {
+        response.json().then((data) => {
+          if (mounted) {
+            setSrc(data.url);
+          }
+        });
+      });
+    }
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return src ? <Avatar variant="rounded" src={src} /> : null;
+}
+
+function CustomComponentList() {
+  const { authenticated, token } = usePrismaticAuth();
+  const [marketPlaceLoading, setMarketplaceLoading] = React.useState(true);
+  const [components, setComponents] = React.useState<Component[]>([]);
+
+  React.useEffect(() => {
+    let mounted = true;
+
+    if (authenticated && token) {
+      const fetchMarketplaceData = async () => {
+        const query = `query getComponents($cursor: String) {
+          components(after: $cursor, sortBy: {direction: ASC, field: LABEL}) {
+            nodes {
+              id
+              versionNumber
+              label
+              description
+              iconUrl
+              public
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+        `;
+        let components: Component[] = [];
+        let cursor: string = "";
+
+        /** The Prismatic API is paginated; loop over pages of 100 records of components until there are no more pages to fetch. */
+        do {
+          const response = await prismatic.graphqlRequest({
+            query,
+            variables: { cursor },
+          });
+          components = components.concat(response.data.components.nodes);
+          cursor = response.data.components.pageInfo.endCursor;
+        } while (cursor);
+
+        if (mounted) {
+          setComponents(components);
+          setMarketplaceLoading(false);
+        }
+      };
+      fetchMarketplaceData();
+    }
+
+    return () => {
+      mounted = false;
+    };
+  }, [authenticated, token]);
+
+  return (
+    <>
+      <Head>
+        <title>Components in Custom UI Elements</title>
+      </Head>
+      <PageTitleWrapper>
+        <ExampleHeader markdown={customComponentListHelperText} />
+      </PageTitleWrapper>
+      {marketPlaceLoading ? (
+        <Container>
+          <LinearProgress />
+        </Container>
+      ) : (
+        <Container>
+          <Grid container spacing={2}>
+            {components.map((component) => (
+              <Grid
+                item
+                xs={6}
+                md={4}
+                key={component.id}
+                display="stretch"
+                flexDirection="column"
+              >
+                <Card
+                  elevation={3}
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    justifyContent: "space-between",
+                    height: "100%",
+                  }}
+                >
+                  <CardHeader
+                    avatar={
+                      <PrismaticAvatar
+                        avatarUrl={component.iconUrl}
+                        token={token}
+                      />
+                    }
+                    title={`${component.label} - v${component.versionNumber} `}
+                  />
+                  <CardContent>
+                    <Typography variant="body2" color="text.secondary">
+                      {!component.public && <strong>Private: </strong>}
+                      {component.description}
+                    </Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))}
+          </Grid>
+        </Container>
+      )}
+      <Footer />
+    </>
+  );
+}
+
+CustomComponentList.getLayout = (page) => (
+  <SidebarLayout titleMarginBottom={4}>{page}</SidebarLayout>
+);
+export default CustomComponentList;


### PR DESCRIPTION
This embedded example shows how someone could query the Prismatic API for a list of components, and display those components in custom UI elements. This example is often used for marketing, to display to customers a list of components that they could use in the embedded designer.