### PR TITLE
Preload the application assets and cache connections

### DIFF
--- a/example-embedded-app/package-lock.json
+++ b/example-embedded-app/package-lock.json
@@ -49,7 +49,7 @@
     },
     "..": {
       "name": "@prismatic-io/embedded",
-      "version": "2.5.2",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "^8.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "2.5.2",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -18,7 +18,7 @@ export interface InitProps
       State,
       "screenConfiguration" | "theme" | "fontConfiguration" | "translation"
     >,
-    Partial<Pick<State, "filters" | "prismaticUrl">> {}
+    Partial<Pick<State, "filters" | "prismaticUrl" | "skipPreload">> {}
 
 export const EMBEDDED_DEFAULTS = {
   filters: {
@@ -34,6 +34,7 @@ export const EMBEDDED_DEFAULTS = {
     marketplace: {},
     initializing: {},
   },
+  skipPreload: false,
   theme: "LIGHT",
   fontConfiguration: undefined,
   translation: {},
@@ -60,6 +61,24 @@ export const init = (optionsBase?: InitProps) => {
 
   if (existingElement) {
     return;
+  }
+
+  /**
+   * This establishes a connection to the prismatic url and preloads
+   * assets (css, js, fonts, etc.) into browser cache. Subsequent
+   * calls, use existing connections and cached assets.
+   */
+  if (!options.skipPreload) {
+    document.body.insertAdjacentHTML(
+      "beforeend",
+      `<iframe
+        src="${state.prismaticUrl}/embedded"
+        title="PIO Embedded Preload"
+        height="0"
+        width="0"
+        style="visibility: hidden; display: none;"
+      />`
+    );
   }
 
   document.head.insertAdjacentHTML("beforeend", styles);

--- a/src/state.ts
+++ b/src/state.ts
@@ -11,6 +11,7 @@ export interface State {
   embeddedDesignerEnabled: boolean;
   prismaticUrl: string;
   screenConfiguration?: ScreenConfiguration;
+  skipPreload?: boolean;
   theme?: Theme;
   fontConfiguration?: FontConfiguration;
   translation?: Translation;


### PR DESCRIPTION
**Issue:**
We need a method to pre-load assets and connections when making calls within the embedded SDK.

**Tried Solutions:**
- `dns-prefetch`: Unnecessary because DNS resolution to obtain the cached IP address has already been done.
- `preconnect`: Establishing a `preconnect` from the top frame origin for resources referenced in the iframe will not function properly due to the differing origins between the top frame and the iframe.
- `preload`: This method only preloads specified resources, which is ineffective for our case since our resources are bundled with different hashes. To make this work, we would need to create a remote-fetchable manifest that references these resources. This approach does not seem worthwhile.
- `prerender`: Deprecating in Chrome and Edge, and already deprecated in Safari and Firefox.
- `prefetch`: Only applicable for same-origin resources.

**Solution: **
Develop a publicly accessible `embedded` route which is initially blank but contains all the necessary assets (css, js, fonts, etc.) for caching. The connections are also shared among iframe origins. I confirmed that the assets are all the hashed the same, as you navigate the application. 

Lifecycle of the Embedded:
1. Begin the embedded process.
2. Introduce a ghost iframe that directs to `/embedded`.
3. Cache all assets in the browser to share them during future embedded SDK method calls.
4. Share all connections for future embedded SDK method calls.