### PR TITLE
Config variables emitted with marketplace events will now include ID and OAuth status

### DIFF
--- a/example-embedded-app/package-lock.json
+++ b/example-embedded-app/package-lock.json
@@ -49,7 +49,7 @@
     },
     "..": {
       "name": "@prismatic-io/embedded",
-      "version": "2.6.0",
+      "version": "2.6.2",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "^8.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/spectral": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/configVars.ts
+++ b/src/types/configVars.ts
@@ -16,6 +16,7 @@ type CollectionTypeEnum = "valuelist" | "keyvaluelist";
 type CodeLanguageEnum = "json" | "xml" | "html";
 
 interface BaseConfigVar {
+  id: string;
   codeLanguage: CodeLanguageEnum | null;
   collectionType: CollectionTypeEnum | null;
   dataType: DefaultConfigVarDataTypeEnum | null;
@@ -50,7 +51,7 @@ enum InstanceConfigVariableStatus {
   PENDING = "PENDING",
 }
 
-export interface ConnectionConfigVar {
+export interface ConnectionConfigVar extends BaseConfigVar {
   inputs: Record<string, { value: string }>;
   status: InstanceConfigVariableStatus | null;
 }


### PR DESCRIPTION
This prepares embedded for an upcoming change where the `INSTANCE_CONFIGURATION_LOADED` event will now include config variable `id` and `status` (for OAuth connection config variables). The `ConnectionConfigVar` type already included `status`, but needed the other properties a config variable has (defined in `BaseConfigVar`).