### PR TITLE
JWT token refresh example for example app

### DIFF
--- a/example-embedded-app/pages/api/prismatic-auth.tsx
+++ b/example-embedded-app/pages/api/prismatic-auth.tsx
@@ -18,7 +18,7 @@ export default function handler(_req, res) {
       customer: config.customer,
       nbf: currentTime,
       iat: currentTime,
-      exp: currentTime + 60 * 60 * 4, // 4 hours from now
+      exp: currentTime + config.tokenValidSeconds,
       role: config.role,
     },
     config.signingKey, // Store this somewhere safe

--- a/example-embedded-app/pages/examples/custom-ui-elements.tsx
+++ b/example-embedded-app/pages/examples/custom-ui-elements.tsx
@@ -216,6 +216,7 @@ function CustomUiElements() {
                             screenConfiguration: {
                               configurationWizard: { isInModal: true },
                             },
+                            skipRedirectOnRemove: true,
                           })
                         }
                       >

--- a/example-embedded-app/prismatic/config.ts.template
+++ b/example-embedded-app/prismatic/config.ts.template
@@ -22,7 +22,8 @@ const config: PrismaticConfig = {
   customer: 'my-customer-external-id',
   name: 'John Doe',
   signingKey,
-  role: 'admin'
+  role: 'admin',
+  tokenValidSeconds: 60 * 5, // 5 minutes
 };
 
 export default config;

--- a/example-embedded-app/prismatic/types.ts
+++ b/example-embedded-app/prismatic/types.ts
@@ -23,6 +23,9 @@ export interface PrismaticConfig {
   /** Signing key for signing JWT access tokens */
   signingKey: string;
 
+  /** The duration for which the generated JWT is valid */
+  tokenValidSeconds: number;
+
   /**
    * Optional Prismatic API refresh token. This can be used to query the Prismatic API from the backend
    * as an organization user. You can generate a refresh token with `prism me:token --type refresh`.

--- a/example-embedded-app/src/usePrismaticAuth.ts
+++ b/example-embedded-app/src/usePrismaticAuth.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import Router from "next/router";
 import prismatic from "@prismatic-io/embedded";
 import React, { useEffect, useMemo } from "react";
+import config from "../prismatic/config";
 
 interface UserInfoProps {
   authenticatedUser: {
@@ -36,6 +37,9 @@ const getUserInfo = async (): Promise<UserInfoProps> => {
   return result.data;
 };
 
+// Refresh Prismatic token 30 seconds before it expires
+const prismaticTokenRefreshInterval = (config.tokenValidSeconds - 30) * 1000;
+
 /**
  * Authenticate with Prismatic and return an auth token and info about the authenticated user.
  */
@@ -46,6 +50,7 @@ const usePrismaticAuth = (): AuthConfig => {
   const { data, error } = useSWR<{ token: string }>(
     "/api/prismatic-auth",
     fetcher,
+    { refreshInterval: prismaticTokenRefreshInterval },
   );
 
   const token = useMemo(() => data?.token, [data?.token]);


### PR DESCRIPTION
Embedded tokens can (and should) have a short expiration time, and tokens used by iframes, etc., can be refreshed automatically be calling `prismatic.authenticate()` with a newly generated token.

This adds token refresh to our example embedded app. Users can specify `tokenValidSeconds` in their config, and tokens will automatically refresh 30 seconds ahead of token expiration.