### PR TITLE
Automatically refresh the auth token in the example app

### DIFF
--- a/example-embedded-app/pages/api/prismatic-auth.tsx
+++ b/example-embedded-app/pages/api/prismatic-auth.tsx
@@ -18,7 +18,7 @@ export default function handler(_req, res) {
       customer: config.customer,
       nbf: currentTime,
       iat: currentTime,
-      exp: currentTime + 60 * 60 * 4, // 4 hours from now
+      exp: currentTime + config.tokenValidSeconds,
       role: config.role,
     },
     config.signingKey, // Store this somewhere safe

--- a/example-embedded-app/prismatic/types.ts
+++ b/example-embedded-app/prismatic/types.ts
@@ -31,4 +31,11 @@ export interface PrismaticConfig {
    * for documentation
    */
   prismaticRefreshToken?: string;
+
+  /**
+   * Duration the auth token is valid in seconds.
+   * usePrismaticAuth.ts will automatically refresh the auth token
+   * 30 seconds before it expires.
+   */
+  tokenValidSeconds: number;
 }

--- a/example-embedded-app/src/usePrismaticAuth.ts
+++ b/example-embedded-app/src/usePrismaticAuth.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import Router from "next/router";
 import prismatic from "@prismatic-io/embedded";
 import React, { useEffect, useMemo } from "react";
+import config from "../prismatic/config";
 
 interface UserInfoProps {
   authenticatedUser: {
@@ -46,6 +47,7 @@ const usePrismaticAuth = (): AuthConfig => {
   const { data, error } = useSWR<{ token: string }>(
     "/api/prismatic-auth",
     fetcher,
+    { refreshInterval: (config.tokenValidSeconds - 30) * 1000 }, // Refresh token 30 seconds before expiration
   );
 
   const token = useMemo(() => data?.token, [data?.token]);


### PR DESCRIPTION
It's best practice to generate short-lived JWTs for the embedded markeplace, and to refresh the tokens before they expire. This adds a new config setting to the example embedded app, `tokenValidSeconds`, which determines how many seconds the token is valid for. The `usePrismaticAuth` hook is configured now to fetch a new token 30 seconds before the token expires. When a new token is detected, the `useEffect` within that hook re-issues a `prismatic.authenticate()` call with the new token.