### PR TITLE
Add customer upsert to example app

### DIFF
--- a/example-embedded-app/package-lock.json
+++ b/example-embedded-app/package-lock.json
@@ -48,7 +48,7 @@
     },
     "..": {
       "name": "@prismatic-io/embedded",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/translations": "^2.1.1",

--- a/example-embedded-app/pages/api/prismatic-auth.tsx
+++ b/example-embedded-app/pages/api/prismatic-auth.tsx
@@ -16,6 +16,7 @@ export default function handler(_req, res) {
       name: config.name,
       organization: config.organization,
       customer: config.customer,
+      customer_name: config.customerName,
       nbf: currentTime,
       iat: currentTime,
       exp: currentTime + config.tokenValidSeconds,

--- a/example-embedded-app/prismatic/config.ts.template
+++ b/example-embedded-app/prismatic/config.ts.template
@@ -20,6 +20,7 @@ const config: PrismaticConfig = {
   organization:
     'T3JnYW5pemF0aW9uOjAwMDAwMDAwLTAwMDAwMDAwLTAwMDAwMDAwLTAwMDAwMDAw',
   customer: 'my-customer-external-id',
+  customerName: 'Hooli',
   name: 'John Doe',
   signingKey,
   role: 'admin'

--- a/example-embedded-app/prismatic/types.ts
+++ b/example-embedded-app/prismatic/types.ts
@@ -11,6 +11,9 @@ export interface PrismaticConfig {
   /** The external ID of the customer */
   customer: string;
 
+  /** The name of the customer to create (if it does not exist) */
+  customerName?: string;
+
   /** The role of the user. "user" is only used for user-level config. Generally, you'll want to use "admin". Defaults to "admin" */
   role?: "admin" | "user";
 


### PR DESCRIPTION
You can now add a `customer_name` claim to a signed JWT. When `customer_name` is present, and the customer specified by the `customer` external ID claim does not yet exist, the a new customer record will be automatically created.

This demonstrates how to add a `customer_name` claim to the signed JWT in the example app.