### PR TITLE
Bump embedded SDK to latest in example embedded app

### DIFF
--- a/example-embedded-app/package-lock.json
+++ b/example-embedded-app/package-lock.json
@@ -48,7 +48,7 @@
     },
     "..": {
       "name": "@prismatic-io/embedded",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/translations": "^2.1.1",

--- a/example-embedded-app/pages/examples/custom-ui-elements.tsx
+++ b/example-embedded-app/pages/examples/custom-ui-elements.tsx
@@ -202,7 +202,7 @@ function CustomUiElements() {
                             : "secondary"
                         }
                         onClick={() =>
-                          prismatic.configureIntegration({
+                          prismatic.configureInstance({
                             integrationName: integration.name,
                             theme: "LIGHT",
                             usePopover: true,

--- a/example-embedded-app/src/components/PageTitleWrapper.tsx
+++ b/example-embedded-app/src/components/PageTitleWrapper.tsx
@@ -1,6 +1,5 @@
-import { FC, ReactNode } from "react";
-import PropTypes from "prop-types";
 import { Box, Container, styled } from "@mui/material";
+import { FC, ReactNode } from "react";
 
 const PageTitle = styled(Box)(({ theme }) => ({
   padding: theme.spacing(3),
@@ -16,10 +15,6 @@ const PageTitleWrapper: FC<PageTitleWrapperProps> = ({ children }) => {
       <Container maxWidth="lg">{children}</Container>
     </PageTitle>
   );
-};
-
-PageTitleWrapper.propTypes = {
-  children: PropTypes.node.isRequired,
 };
 
 export default PageTitleWrapper;

--- a/example-embedded-app/src/components/Scrollbar.tsx
+++ b/example-embedded-app/src/components/Scrollbar.tsx
@@ -40,7 +40,6 @@ const Scrollbar: FC<ScrollbarProps> = ({ className, children, ...rest }) => {
 };
 
 Scrollbar.propTypes = {
-  children: PropTypes.node,
   className: PropTypes.string,
 };
 

--- a/example-embedded-app/src/components/Text.tsx
+++ b/example-embedded-app/src/components/Text.tsx
@@ -77,7 +77,6 @@ const Text: FC<TextProps> = ({
 };
 
 Text.propTypes = {
-  children: PropTypes.node,
   className: PropTypes.string,
   color: PropTypes.oneOf([
     "primary",

--- a/example-embedded-app/src/layouts/SidebarLayout/index.tsx
+++ b/example-embedded-app/src/layouts/SidebarLayout/index.tsx
@@ -1,9 +1,8 @@
-import { FC, ReactNode } from "react";
 import { Box, alpha, useTheme } from "@mui/material";
-import PropTypes from "prop-types";
+import { FC, ReactNode } from "react";
 
-import Sidebar from "./Sidebar";
 import Header from "./Header";
+import Sidebar from "./Sidebar";
 
 interface SidebarLayoutProps {
   children?: ReactNode;
@@ -58,10 +57,6 @@ const SidebarLayout: FC<SidebarLayoutProps> = ({
       </Box>
     </>
   );
-};
-
-SidebarLayout.propTypes = {
-  children: PropTypes.node,
 };
 
 export default SidebarLayout;


### PR DESCRIPTION
This PR does two things:
- Updates `@prismatic-io/embedded` to latest in the example embedded app and swaps `prismatic.configureIntegration` for `prismatic.configureInstance`.
- An older version bump of `@types/react` changed the type of `propTypes.children`, which causes build errors if you attempt to build the project. They can be safely removed.