### PR TITLE
Add `queryWorkflows` and `createWorkflow` methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/embedded",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/embedded",
-      "version": "4.6.0",
+      "version": "4.7.0",
       "license": "MIT",
       "dependencies": {
         "@prismatic-io/translations": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/embedded.git"
   },
   "license": "MIT",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/lib/authenticate.ts
+++ b/src/lib/authenticate.ts
@@ -77,7 +77,11 @@ export const authenticate = async (options: AuthenticateProps) => {
 
   stateService.setState(state);
 
-  const result = await graphqlRequest({
+  const result = await graphqlRequest<{
+    authenticatedUser: {
+      customer: { allowEmbeddedDesigner: boolean };
+    };
+  }>({
     query: `{
       authenticatedUser {
         customer {

--- a/src/lib/createWorkflow.ts
+++ b/src/lib/createWorkflow.ts
@@ -1,0 +1,71 @@
+import { assertInit } from "../utils/assertInit";
+import { graphqlRequest } from "./graphqlRequest";
+
+export interface WorkflowContexts {}
+
+interface CreateWorkflowArgs<TContextData = unknown> {
+  name: string;
+  contextData: TContextData;
+  externalId?: string;
+}
+
+interface CreateWorkflowData {
+  importWorkflow: {
+    workflow: {
+      id: string;
+    };
+    errors: {
+      field: string;
+      messages: string[];
+    }[];
+  };
+}
+
+interface CreateWorkflowVariables {
+  name: string;
+  contextStableKey: string;
+  contextData: string;
+  externalId?: string;
+}
+
+const mutation = `
+  mutation createWorkflow($name: String!, $contextStableKey: String, $contextData: String, $externalId: String) {
+    importWorkflow(input: {
+      name: $name
+      contextStableKey: $contextStableKey
+      contextData: $contextData
+      externalId: $externalId
+    }) {
+      workflow {
+        id
+      }
+      errors {
+        field
+        messages
+      }
+    }
+  }
+`;
+
+export async function createWorkflow<
+  TKey extends keyof WorkflowContexts | (string & {})
+>(
+  contextStableKey: TKey,
+  args: CreateWorkflowArgs<
+    TKey extends keyof WorkflowContexts
+      ? WorkflowContexts[TKey]
+      : Record<string, unknown>
+  >
+) {
+  assertInit("createWorkflow");
+
+  return graphqlRequest<CreateWorkflowData, CreateWorkflowVariables>({
+    query: mutation,
+    variables: {
+      name: args.name,
+      contextStableKey,
+      contextData: JSON.stringify(args.contextData),
+      externalId: args.externalId,
+    },
+  });
+}

--- a/src/lib/graphqlRequest.ts
+++ b/src/lib/graphqlRequest.ts
@@ -3,15 +3,25 @@ import urlJoin from "url-join";
 import stateService from "../state";
 import { assertInit } from "../utils/assertInit";
 
-export interface GraphqlRequestProps {
+export interface GraphqlRequestProps<
+  TVariables = Record<string, unknown>
+> {
   query: string;
-  variables?: Record<string, unknown>;
+  variables?: TVariables;
 }
 
-export const graphqlRequest = async ({
+export interface GraphqlRequestResponse<TData = unknown> {
+  data: TData;
+  errors?: { message: string }[];
+}
+
+export const graphqlRequest = async <
+  TData = unknown,
+  TVariables = Record<string, unknown>
+>({
   query,
   variables,
-}: GraphqlRequestProps) => {
+}: GraphqlRequestProps<TVariables>): Promise<GraphqlRequestResponse<TData>> => {
   assertInit("authenticate");
 
   const { jwt, prismaticUrl } = stateService.getStateCopy();

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,6 +6,7 @@ import {
 } from "./configureInstance";
 
 export { authenticate } from "./authenticate";
+export { createWorkflow } from "./createWorkflow";
 export {
   configureInstance,
   isConfigureInstanceWithInstanceId,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -24,5 +24,6 @@ export { showDesigner } from "./showDesigner";
 export { showIntegrations } from "./showIntegrations";
 export { showLogs } from "./showLogs";
 export { showMarketplace } from "./showMarketplace";
+export { queryWorkflows } from "./queryWorkflows";
 export { showWorkflow } from "./showWorkflow";
 export { showWorkflows } from "./showWorkflows";

--- a/src/lib/queryWorkflows.ts
+++ b/src/lib/queryWorkflows.ts
@@ -1,0 +1,112 @@
+import { assertInit } from "../utils/assertInit";
+import { graphqlRequest } from "./graphqlRequest";
+
+interface Workflow {
+  id: string;
+  name: string;
+  versionNumber: number;
+  description: string;
+  updatedAt: string;
+  lastExecutedAt: string | null;
+  createdAt: string;
+  category: string | null;
+  labels: string[];
+  customer: {
+    id: string;
+    name: string;
+  };
+  instance: {
+    enabled: boolean;
+  } | null;
+  deployedVersion: {
+    id: string;
+  } | null;
+}
+
+interface QueryWorkflowsData {
+  workflows: {
+    nodes: Workflow[];
+    pageInfo: {
+      hasNextPage: boolean;
+      endCursor: string | null;
+    };
+    totalCount: number;
+  };
+}
+
+export interface QueryWorkflowsProps extends Record<string, unknown> {
+  searchTerm?: string;
+  descriptionSearch?: string;
+  categorySearch?: string;
+  labelSearch?: string;
+  contextStableKey?: string;
+  externalId?: string;
+  sortBy?: string[];
+  first?: number;
+  cursor?: string;
+}
+
+const query = `
+  query queryWorkflows(
+    $cursor: String
+    $searchTerm: String
+    $descriptionSearch: String
+    $categorySearch: String
+    $labelSearch: String
+    $contextStableKey: String
+    $externalId: String
+    $first: Int
+    $sortBy: [IntegrationVariantOrder]
+  ) {
+    workflows: integrationVariants(
+      after: $cursor
+      name_Icontains: $searchTerm
+      description_Icontains: $descriptionSearch
+      category: $categorySearch
+      labels_Icontains: $labelSearch
+      contextStableKey: $contextStableKey
+      externalId: $externalId
+      exclude: [INTEGRATION]
+      first: $first
+      sortBy: $sortBy
+    ) {
+      nodes {
+        ... on Workflow {
+          id
+          name
+          versionNumber
+          description
+          updatedAt
+          lastExecutedAt
+          createdAt
+          category
+          labels
+          customer {
+            id
+            name
+          }
+          instance {
+            enabled
+          }
+          deployedVersion {
+            id
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+    }
+  }
+`;
+
+export const queryWorkflows = async (variables?: QueryWorkflowsProps) => {
+  assertInit("queryWorkflows");
+
+  return graphqlRequest<QueryWorkflowsData, QueryWorkflowsProps>({
+    query,
+    variables,
+  });
+};


### PR DESCRIPTION
This introduces two additional methods for interacting with workflows made with EWB:

**queryWorkflows**
Returns a filtered list of workflows. Notably, this allows filtering by `contextStableKey` and `externalId` so embedding applications can list workflows attached to a given entity in their applications.

**createWorkflow**
Allows creating a new workflow from a workflow context by supplying the required context data and optional external id. 