### PR TITLE
Improve JSDoc for embedded functions

### DIFF
--- a/src/lib/authenticate.ts
+++ b/src/lib/authenticate.ts
@@ -15,6 +15,38 @@ export interface AuthenticateProps {
   token: string;
 }
 
+/**
+ * Authenticates an embedded user with a signed JWT token. This must be called after
+ * {@link init} and before rendering any embedded screens. The token should be a
+ * short-lived RS256-signed JWT generated on your backend.
+ *
+ * After the initial call, call `authenticate` again before the token expires
+ * (typically ~60 seconds before expiry) to keep the session alive. All active
+ * iframes update automatically when a new token is provided.
+ *
+ * @param options - Authentication options.
+ * @param options.token - A signed JWT containing `sub`, `organization`, `customer`, `iat`, and `exp` claims.
+ * @param options.prismaticUrl - Override the Prismatic app URL for this authentication request.
+ * @throws {Error} If the token is missing or the server rejects it.
+ *
+ * @example
+ * // Authenticate with a token fetched from your backend
+ * const response = await fetch("/api/prismatic-token");
+ * const { token } = await response.json();
+ * await prismatic.authenticate({ token });
+ *
+ * @example
+ * // Re-authenticate before token expiry
+ * const TOKEN_LIFETIME_MS = 10 * 60 * 1000; // 10 minutes
+ * const refreshToken = async () => {
+ *   const { token } = await fetchToken();
+ *   await prismatic.authenticate({ token });
+ *   setTimeout(refreshToken, TOKEN_LIFETIME_MS - 60_000);
+ * };
+ * refreshToken();
+ *
+ * @see {@link https://prismatic.io/docs/embed/authenticate-users/ | Authenticating Embedded Users}
+ */
 export const authenticate = async (options: AuthenticateProps) => {
   assertInit("authenticate");
 

--- a/src/lib/configureInstance.ts
+++ b/src/lib/configureInstance.ts
@@ -23,6 +23,37 @@ export type ConfigureInstanceProps =
   | ConfigureInstanceWithIntegrationId
   | ConfigureInstanceWithInstanceId;
 
+/**
+ * Opens the configuration wizard for an integration, allowing a customer user
+ * to activate and configure an instance. You can identify the target by
+ * `integrationName`, `integrationId`, or `instanceId`.
+ *
+ * - Use `integrationName` to let a customer activate a new instance of a
+ *   marketplace integration by its display name.
+ * - Use `integrationId` to target a specific integration version.
+ * - Use `instanceId` to reconfigure an already-deployed instance.
+ *
+ * @param props - Configuration options. Exactly one of `integrationName`, `integrationId`, or `instanceId` is required.
+ * @param props.skipRedirectOnRemove - When `true`, prevents redirecting to the marketplace after the instance is removed.
+ *
+ * @example
+ * // Configure by integration name (most common)
+ * prismatic.configureInstance({
+ *   integrationName: "Salesforce",
+ *   usePopover: true,
+ *   skipRedirectOnRemove: false,
+ * });
+ *
+ * @example
+ * // Reconfigure an existing instance inline
+ * prismatic.configureInstance({
+ *   instanceId: "SW5zdGFuY2U6OGE2YjZi...",
+ *   selector: "#config-container",
+ *   skipRedirectOnRemove: true,
+ * });
+ *
+ * @see {@link https://prismatic.io/docs/embed/marketplace/ | Embedding the Marketplace}
+ */
 export const configureInstance = ({ ...props }: ConfigureInstanceProps) => {
   assertInit("configureInstance");
 
@@ -54,18 +85,21 @@ export const configureInstance = ({ ...props }: ConfigureInstanceProps) => {
   }
 };
 
+/** Type guard that checks whether the props identify a target instance by `instanceId`. */
 export const isConfigureInstanceWithInstanceId = (
   props: ConfigureInstanceProps,
 ): props is ConfigureInstanceWithInstanceId => {
   return Boolean("instanceId" in props && props.instanceId);
 };
 
+/** Type guard that checks whether the props identify a target integration by `integrationId`. */
 export const isConfigureInstanceWithIntegrationId = (
   props: ConfigureInstanceProps,
 ): props is ConfigureInstanceWithIntegrationId => {
   return Boolean("integrationId" in props && props.integrationId);
 };
 
+/** Type guard that checks whether the props identify a target integration by `integrationName`. */
 export const isConfigureInstanceWithIntegrationName = (
   props: ConfigureInstanceProps,
 ): props is ConfigureInstanceWithIntegrationName => {

--- a/src/lib/editInstanceConfiguration.ts
+++ b/src/lib/editInstanceConfiguration.ts
@@ -16,6 +16,40 @@ export type EditInstanceConfigurationProps = {
   onDelete?: () => void;
 };
 
+/**
+ * Renders the configuration wizard for an existing instance directly into a
+ * DOM element (no popover). This is useful when you want to embed instance
+ * configuration inline within your own application's UI.
+ *
+ * Unlike {@link configureInstance}, this function opens the config wizard directly,
+ * supports lifecycle callbacks (`onSuccess`, `onCancel`, `onDelete`), and returns a
+ * cleanup function to remove event listeners.
+ *
+ * @param props - Configuration and display options.
+ * @param props.instanceId - The ID of the instance to configure.
+ * @param props.selector - A CSS selector for the DOM element to render into.
+ * @param props.theme - Optional theme override (`"LIGHT"` or `"DARK"`).
+ * @param props.screenConfiguration - Optional screen configuration for the configuration wizard.
+ * @param props.onSuccess - Called when the instance is successfully deployed.
+ * @param props.onCancel - Called when the user cancels the configuration.
+ * @param props.onDelete - Called when the user deletes the instance.
+ * @returns A cleanup function that removes the event listeners, or `undefined` if no callbacks were provided.
+ *
+ * @example
+ * // Edit an instance's configuration with lifecycle callbacks
+ * const cleanup = prismatic.editInstanceConfiguration({
+ *   instanceId: "SW5zdGFuY2U6OGE2YjZi...",
+ *   selector: "#config-panel",
+ *   onSuccess: () => console.log("Configuration saved!"),
+ *   onCancel: () => console.log("Configuration canceled."),
+ *   onDelete: () => console.log("Instance deleted."),
+ * });
+ *
+ * // Call cleanup() when you're done to remove event listeners
+ * cleanup?.();
+ *
+ * @see {@link https://prismatic.io/docs/embed/marketplace/ | Embedding the Marketplace}
+ */
 export const editInstanceConfiguration = ({
   instanceId,
   selector,

--- a/src/lib/graphqlRequest.ts
+++ b/src/lib/graphqlRequest.ts
@@ -13,6 +13,51 @@ export interface GraphqlRequestResponse<TData = unknown> {
   errors?: { message: string }[];
 }
 
+/**
+ * Executes an authenticated GraphQL request against the Prismatic API.
+ * The request is automatically authorized using the JWT from the most
+ * recent {@link authenticate} call.
+ *
+ * This is useful for building custom UIs — for example, querying
+ * `marketplaceIntegrations` to render a custom marketplace.
+ *
+ * @param props - The GraphQL query and optional variables.
+ * @param props.query - The GraphQL query string.
+ * @param props.variables - Optional variables to pass to the query.
+ * @returns The parsed JSON response from the Prismatic API.
+ *
+ * @example
+ * // Query available marketplace integrations
+ * const result = await prismatic.graphqlRequest({
+ *   query: `{
+ *     marketplaceIntegrations(
+ *       filters: { category: "ERP" }
+ *     ) {
+ *       nodes {
+ *         id
+ *         name
+ *         description
+ *         category
+ *       }
+ *     }
+ *   }`,
+ * });
+ * console.log(result.data.marketplaceIntegrations.nodes);
+ *
+ * @example
+ * // Query with variables
+ * const result = await prismatic.graphqlRequest({
+ *   query: `query ($integrationId: ID!) {
+ *     integration(id: $integrationId) {
+ *       name
+ *       instances { nodes { id name } }
+ *     }
+ *   }`,
+ *   variables: { integrationId: "SW50ZWdyYXRpb246..." },
+ * });
+ *
+ * @see {@link https://prismatic.io/docs/embed/embedded-api-requests/ | Embedded API Requests}
+ */
 export const graphqlRequest = async <
   TData = unknown,
   TVariables = Record<string, unknown>,

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -40,6 +40,43 @@ export const EMBEDDED_DEFAULTS = {
   translation: {},
 };
 
+/**
+ * Initializes the Prismatic embedded SDK. This must be called once before any other
+ * SDK methods. It sets up the popover overlay, preloads Prismatic assets into the
+ * browser cache, and applies global configuration (theme, filters, translations, etc.).
+ *
+ * Calling `init` again resets the SDK to a fresh state with the new options.
+ *
+ * @param optionsBase - Optional global configuration for the embedded SDK.
+ * @param optionsBase.theme - The color theme to use (`"LIGHT"` or `"DARK"`). Defaults to `"LIGHT"`.
+ * @param optionsBase.fontConfiguration - Google Font families to load for the embedded UI.
+ * @param optionsBase.screenConfiguration - Per-screen display options (marketplace, config wizard, dashboard, etc.).
+ * @param optionsBase.filters - Default filters for the marketplace, integrations, and components screens.
+ * @param optionsBase.translation - Custom phrase overrides and debug mode for i18n.
+ * @param optionsBase.prismaticUrl - Override the Prismatic app URL. Defaults to `"https://app.prismatic.io"`.
+ * @param optionsBase.skipPreload - Skip preloading Prismatic assets. Defaults to `false`.
+ *
+ * @example
+ * // Basic initialization with defaults
+ * prismatic.init();
+ *
+ * @example
+ * // Initialize with dark theme and custom screen configuration
+ * prismatic.init({
+ *   theme: "DARK",
+ *   screenConfiguration: {
+ *     marketplace: { configuration: "allow-details" },
+ *     configurationWizard: { mode: "streamlined" },
+ *   },
+ *   filters: {
+ *     marketplace: { category: "ERP" },
+ *   },
+ * });
+ *
+ * @see {@link https://prismatic.io/docs/embed/get-started/install-embedded-sdk/ | Installing the Embedded SDK}
+ * @see {@link https://prismatic.io/docs/embed/theming/ | Theming}
+ * @see {@link https://prismatic.io/docs/embed/translations-and-internationalization/ | Translations & i18n}
+ */
 export const init = (optionsBase?: InitProps) => {
   const options: InitProps = merge({}, EMBEDDED_DEFAULTS, optionsBase);
 

--- a/src/lib/setConfigVars.ts
+++ b/src/lib/setConfigVars.ts
@@ -18,6 +18,45 @@ export type SetConfigVarsProps =
   | IFrameSetConfigVarProps
   | SelectorSetConfigVarProps;
 
+/**
+ * Programmatically sets configuration variable values on an active configuration
+ * wizard. This is useful for pre-filling config values based on context from
+ * your application (e.g., setting an API endpoint or customer-specific settings).
+ *
+ * You can target the iframe either by passing the iframe element directly
+ * (obtained from {@link getMessageIframe}) or by passing a `selector` string.
+ *
+ * @param props - The config vars and target iframe.
+ * @param props.configVars - A map of config variable keys to their values.
+ * @param props.iframe - The iframe element to send config vars to (use with `getMessageIframe`).
+ * @param props.selector - A CSS selector for the iframe to send config vars to.
+ *
+ * @example
+ * // Set config vars using an iframe reference from a message event
+ * window.addEventListener("message", (event) => {
+ *   if (event.data.event === "INSTANCE_CONFIGURATION_LOADED") {
+ *     const iframe = prismatic.getMessageIframe(event);
+ *     prismatic.setConfigVars({
+ *       iframe,
+ *       configVars: {
+ *         "API Endpoint": { value: "https://api.example.com" },
+ *         "Sync Frequency": { value: "daily" },
+ *       },
+ *     });
+ *   }
+ * });
+ *
+ * @example
+ * // Set config vars using a CSS selector
+ * prismatic.setConfigVars({
+ *   selector: "#config-container",
+ *   configVars: {
+ *     "API Key": { value: "my-api-key" },
+ *   },
+ * });
+ *
+ * @see {@link https://prismatic.io/docs/embed/marketplace/ | Embedding the Marketplace}
+ */
 export const setConfigVars = ({
   configVars,
   ...options

--- a/src/lib/showComponent.ts
+++ b/src/lib/showComponent.ts
@@ -6,6 +6,29 @@ export type ShowComponentProps = Options & {
   componentId: string;
 };
 
+/**
+ * Renders the detail page for a specific component, showing its available
+ * actions, triggers, and data sources.
+ *
+ * @param props - Display options including the component to show.
+ * @param props.componentId - The ID of the component to display.
+ *
+ * @example
+ * // Show a specific component in a popover
+ * prismatic.showComponent({
+ *   componentId: "Q29tcG9uZW50OmFiY2Rl...",
+ *   usePopover: true,
+ * });
+ *
+ * @example
+ * // Show a specific component inline
+ * prismatic.showComponent({
+ *   componentId: "Q29tcG9uZW50OmFiY2Rl...",
+ *   selector: "#component-detail",
+ * });
+ *
+ * @see {@link https://prismatic.io/docs/embed/additional-screens/show-components/ | Embedding Components}
+ */
 export const showComponent = ({
   componentId,
   ...options

--- a/src/lib/showComponents.ts
+++ b/src/lib/showComponents.ts
@@ -4,6 +4,27 @@ import { setIframe } from "../utils/iframe";
 
 export type ShowComponentsProps = Options & {};
 
+/**
+ * Renders the component browser, where your customer's users can browse
+ * available components and their actions.
+ *
+ * Components can be filtered by category or label via the `filters` option.
+ *
+ * @param options - Display options for the components screen.
+ *
+ * @example
+ * // Show components in a popover
+ * prismatic.showComponents({ usePopover: true });
+ *
+ * @example
+ * // Show components inline, filtered by category
+ * prismatic.showComponents({
+ *   selector: "#components-container",
+ *   filters: { components: { category: "Data Platforms" } },
+ * });
+ *
+ * @see {@link https://prismatic.io/docs/embed/additional-screens/show-components/ | Embedding Components}
+ */
 export const showComponents = (options: ShowComponentsProps) => {
   assertInit("showComponents");
 

--- a/src/lib/showConnections.ts
+++ b/src/lib/showConnections.ts
@@ -4,6 +4,22 @@ import { setIframe } from "../utils/iframe";
 
 export type ShowConnectionsProps = Options & {};
 
+/**
+ * Renders the connections management screen, where your customer's users can
+ * view and manage their reusable credential connections.
+ *
+ * @param options - Display options for the connections screen.
+ *
+ * @example
+ * // Show connections in a popover
+ * prismatic.showConnections({ usePopover: true });
+ *
+ * @example
+ * // Show connections inline
+ * prismatic.showConnections({ selector: "#connections-container" });
+ *
+ * @see {@link https://prismatic.io/docs/embed/additional-screens/show-connections/ | Embedding Connections}
+ */
 export const showConnections = (options: ShowConnectionsProps) => {
   assertInit("showConnections");
 

--- a/src/lib/showDashboard.ts
+++ b/src/lib/showDashboard.ts
@@ -4,6 +4,29 @@ import { setIframe } from "../utils/iframe";
 
 export type ShowDashboardProps = Options & {};
 
+/**
+ * Renders the customer dashboard, which provides an overview of the customer's
+ * deployed instances, logs, connections, and other resources.
+ *
+ * Specific tabs can be hidden via `screenConfiguration.dashboard.hideTabs`.
+ *
+ * @param options - Display options for the dashboard.
+ *
+ * @example
+ * // Show dashboard in a popover
+ * prismatic.showDashboard({ usePopover: true });
+ *
+ * @example
+ * // Show dashboard inline, hiding certain tabs
+ * prismatic.showDashboard({
+ *   selector: "#dashboard-container",
+ *   screenConfiguration: {
+ *     dashboard: { hideTabs: ["Logs", "Credentials"] },
+ *   },
+ * });
+ *
+ * @see {@link https://prismatic.io/docs/embed/additional-screens/show-dashboard/ | Embedding the Dashboard}
+ */
 export const showDashboard = (
   options: ShowDashboardProps = { usePopover: true },
 ) => {

--- a/src/lib/showDesigner.ts
+++ b/src/lib/showDesigner.ts
@@ -7,6 +7,31 @@ export type ShowDesignerProps = Options & {
   integrationId: string;
 };
 
+/**
+ * Renders the embedded integration designer for a specific integration, allowing
+ * your customer's users to build and modify integration workflows.
+ *
+ * Requires the embedded designer feature to be enabled for the customer.
+ *
+ * @param props - Display options including the integration to open.
+ * @param props.integrationId - The ID of the integration to open in the designer.
+ *
+ * @example
+ * // Open the designer for a specific integration in a popover
+ * prismatic.showDesigner({
+ *   integrationId: "SW50ZWdyYXRpb246YzNmOGU...",
+ *   usePopover: true,
+ * });
+ *
+ * @example
+ * // Open the designer inline
+ * prismatic.showDesigner({
+ *   integrationId: "SW50ZWdyYXRpb246YzNmOGU...",
+ *   selector: "#designer-container",
+ * });
+ *
+ * @see {@link https://prismatic.io/docs/embed/workflow-builder/workflow-builder/ | Embedding the Workflow Builder}
+ */
 export const showDesigner = ({
   integrationId,
   ...options

--- a/src/lib/showIntegrations.ts
+++ b/src/lib/showIntegrations.ts
@@ -5,6 +5,22 @@ import { setIframe } from "../utils/iframe";
 
 export type ShowIntegrationsProps = Options & {};
 
+/**
+ * Renders the integrations list screen, where your customer's users can view
+ * and manage integrations they have built with the embedded designer.
+ *
+ * Requires the embedded designer feature to be enabled for the customer.
+ *
+ * @param options - Display options for the integrations list.
+ *
+ * @example
+ * // Show integrations list in a popover
+ * prismatic.showIntegrations({ usePopover: true });
+ *
+ * @example
+ * // Show integrations list inline
+ * prismatic.showIntegrations({ selector: "#integrations-container" });
+ */
 export const showIntegrations = (options: ShowIntegrationsProps) => {
   assertInit("showIntegrations");
   assertEmbeddedDesigner("showIntegrations");

--- a/src/lib/showLogs.ts
+++ b/src/lib/showLogs.ts
@@ -4,6 +4,22 @@ import { setIframe } from "../utils/iframe";
 
 export type ShowLogsProps = Options & {};
 
+/**
+ * Renders the logs screen, where your customer's users can view execution
+ * logs for their deployed instances.
+ *
+ * @param options - Display options for the logs screen.
+ *
+ * @example
+ * // Show logs in a popover
+ * prismatic.showLogs({ usePopover: true });
+ *
+ * @example
+ * // Show logs inline
+ * prismatic.showLogs({ selector: "#logs-container" });
+ *
+ * @see {@link https://prismatic.io/docs/embed/additional-screens/show-logs/ | Embedding Logs}
+ */
 export const showLogs = (options: ShowLogsProps) => {
   assertInit("showLogs");
 

--- a/src/lib/showMarketplace.ts
+++ b/src/lib/showMarketplace.ts
@@ -4,6 +4,29 @@ import { setIframe } from "../utils/iframe";
 
 export type ShowMarketplaceProps = Options & {};
 
+/**
+ * Renders Prismatic's integration marketplace, where your customers can browse,
+ * activate, and configure available integrations.
+ *
+ * The marketplace can be displayed in a popover (default) or rendered inline
+ * within a specific DOM element using the `selector` option.
+ *
+ * @param options - Display options for the marketplace.
+ *
+ * @example
+ * // Show marketplace in a popover
+ * prismatic.showMarketplace({ usePopover: true });
+ *
+ * @example
+ * // Show marketplace inline in a specific DOM element
+ * prismatic.showMarketplace({
+ *   selector: "#marketplace-container",
+ *   theme: "DARK",
+ *   filters: { marketplace: { category: "ERP" } },
+ * });
+ *
+ * @see {@link https://prismatic.io/docs/embed/marketplace/ | Embedding the Marketplace}
+ */
 export const showMarketplace = (
   options: ShowMarketplaceProps = { usePopover: true },
 ) => {

--- a/src/lib/showWorkflow.ts
+++ b/src/lib/showWorkflow.ts
@@ -6,6 +6,29 @@ export type ShowWorkflowBuilderProps = Options & {
   workflowId: string;
 };
 
+/**
+ * Renders the workflow builder for a specific workflow, allowing your customer's
+ * users to view and modify the workflow's steps, triggers, and configuration.
+ *
+ * @param props - Display options including the workflow to open.
+ * @param props.workflowId - The ID of the workflow to open in the builder.
+ *
+ * @example
+ * // Open a specific workflow in a popover
+ * prismatic.showWorkflow({
+ *   workflowId: "V29ya2Zsb3c6YTFiMmMz...",
+ *   usePopover: true,
+ * });
+ *
+ * @example
+ * // Open a specific workflow inline
+ * prismatic.showWorkflow({
+ *   workflowId: "V29ya2Zsb3c6YTFiMmMz...",
+ *   selector: "#workflow-container",
+ * });
+ *
+ * @see {@link https://prismatic.io/docs/embed/workflow-builder/workflow-builder/ | Embedding the Workflow Builder}
+ */
 export const showWorkflow = ({
   workflowId,
   ...options

--- a/src/lib/showWorkflows.ts
+++ b/src/lib/showWorkflows.ts
@@ -4,6 +4,30 @@ import { setIframe } from "../utils/iframe";
 
 export type ShowWorkflowsProps = Options & {};
 
+/**
+ * Renders the workflows list screen, where your customer's users can browse
+ * and manage their workflows.
+ *
+ * Set `screenConfiguration.workflows.includeIntegrations` to also display
+ * integrations alongside workflows.
+ *
+ * @param options - Display options for the workflows list.
+ *
+ * @example
+ * // Show workflows list in a popover
+ * prismatic.showWorkflows({ usePopover: true });
+ *
+ * @example
+ * // Show workflows inline, including integrations
+ * prismatic.showWorkflows({
+ *   selector: "#workflows-container",
+ *   screenConfiguration: {
+ *     workflows: { includeIntegrations: true },
+ *   },
+ * });
+ *
+ * @see {@link https://prismatic.io/docs/embed/workflow-builder/workflow-builder/ | Embedding the Workflow Builder}
+ */
 export const showWorkflows = (options: ShowWorkflowsProps) => {
   assertInit("showWorkflows");
 

--- a/src/utils/popover.ts
+++ b/src/utils/popover.ts
@@ -15,8 +15,27 @@ export const openPopover = () => {
 };
 
 /**
- * Closes an open popover
- * @returns void
+ * Programmatically closes the currently open Prismatic popover. This notifies
+ * the embedded iframe that the marketplace was closed and dispatches a
+ * `POPOVER_CLOSED` event on the window.
+ *
+ * The popover also closes automatically when the user clicks the close button,
+ * clicks the overlay backdrop, or presses the Escape key.
+ *
+ * @example
+ * // Close the popover from your own UI
+ * document.getElementById("my-close-btn")
+ *   .addEventListener("click", () => prismatic.closePopover());
+ *
+ * @example
+ * // Listen for the popover closed event
+ * window.addEventListener("message", (event) => {
+ *   if (event.data.event === "POPOVER_CLOSED") {
+ *     console.log("Popover was closed");
+ *   }
+ * });
+ *
+ * @see {@link https://prismatic.io/docs/embed/marketplace/ | Embedding the Marketplace}
  */
 export const closePopover = () => {
   const iframeElement = getIframeContainerElement(

--- a/src/utils/postMessage.ts
+++ b/src/utils/postMessage.ts
@@ -14,6 +14,30 @@ export interface ElementPostMessage extends PostMessageBase {
 
 type PostMessageProps = SelectorPostMessage | ElementPostMessage;
 
+/**
+ * Returns the iframe element that sent a given `MessageEvent`. This is typically
+ * used inside a `window.addEventListener("message", ...)` handler to identify
+ * which Prismatic iframe dispatched an event, so you can pass it to
+ * {@link setConfigVars} or perform other targeted operations.
+ *
+ * @param event - The `MessageEvent` received from `window.addEventListener("message", ...)`.
+ * @returns The matching `HTMLIFrameElement`, or `undefined` if no iframe matches.
+ *
+ * @example
+ * window.addEventListener("message", (event) => {
+ *   if (event.data.event === "INSTANCE_CONFIGURATION_LOADED") {
+ *     const iframe = prismatic.getMessageIframe(event);
+ *     if (iframe) {
+ *       prismatic.setConfigVars({
+ *         iframe,
+ *         configVars: { "My Config Var": { value: "preset-value" } },
+ *       });
+ *     }
+ *   }
+ * });
+ *
+ * @see {@link https://prismatic.io/docs/embed/marketplace/ | Embedding the Marketplace}
+ */
 export const getMessageIframe = (event: MessageEvent) =>
   Array.from(document.getElementsByTagName("iframe")).find(
     (iframe) => iframe.contentWindow === event.source,


### PR DESCRIPTION
This improves the JSDoc for embedded functions, adding explanations of functions' parameters and example usage. The only code change here is in `src/index.ts`, changing `export default { ...methods }` to `export default methods`, since the former loses JSDoc. I think those function identically. 

<img width="1155" height="458" alt="image" src="https://github.com/user-attachments/assets/ed798493-f5c6-438e-9cbf-1d8098cfaddb" />
