### PR TITLE
Add externalId to Workflow in context aware example

### DIFF
--- a/src/lib/queryWorkflows.ts
+++ b/src/lib/queryWorkflows.ts
@@ -6,6 +6,7 @@ export interface Workflow {
   name: string;
   versionNumber: number;
   description: string;
+  externalId: string | null;
   updatedAt: string;
   lastExecutedAt: string | null;
   createdAt: string;
@@ -76,6 +77,7 @@ const query = `
           name
           versionNumber
           description
+          externalId
           updatedAt
           lastExecutedAt
           createdAt


### PR DESCRIPTION
# Problem
We can filter by `externalId` on `Workflow` but we don't get `externalId` back in the query response. After the API is extended to return `externalId` as a valid field on `Workflow`, we should update `queryWorkflow` to include it.