### PR TITLE
Workflow deleted events

### DIFF
--- a/example-embedded-app/pages/examples/[workflowId]/embedded-workflow-builder.tsx
+++ b/example-embedded-app/pages/examples/[workflowId]/embedded-workflow-builder.tsx
@@ -15,11 +15,13 @@ function Workflow() {
 
   React.useEffect(() => {
     if (authenticated && typeof workflowId === "string" && workflowId) {
-      prismatic.showWorkflow({
+      const cleanup = prismatic.showWorkflow({
         selector: `#${embeddedDivId}`,
         theme: "LIGHT",
         workflowId,
+        onDelete: () => console.log(`Workflow deleted.`),
       });
+      return () => cleanup?.();
     }
   }, [authenticated, workflowId]);
 

--- a/src/lib/showWorkflow.ts
+++ b/src/lib/showWorkflow.ts
@@ -1,9 +1,11 @@
 import type { Options } from "../types/options";
+import { PrismaticMessageEvent } from "../types/postMessage";
 import { assertInit } from "../utils/assertInit";
 import { setIframe } from "../utils/iframe";
 
 export type ShowWorkflowBuilderProps = Options & {
   workflowId: string;
+  onDelete?: () => void;
 };
 
 /**
@@ -12,13 +14,18 @@ export type ShowWorkflowBuilderProps = Options & {
  *
  * @param props - Display options including the workflow to open.
  * @param props.workflowId - The ID of the workflow to open in the builder.
+ * @param props.onDelete - Called when the workflow is deleted.
+ * @returns A cleanup function that removes the event listeners, or `undefined` if onDelete was not provided.
  *
  * @example
  * // Open a specific workflow in a popover
- * prismatic.showWorkflow({
+ * const cleanup = prismatic.showWorkflow({
  *   workflowId: "V29ya2Zsb3c6YTFiMmMz...",
+ *   onDelete: () => console.log(`Workflow deleted.`),
  *   usePopover: true,
  * });
+ * // Call cleanup() when you're done to remove event listeners
+ * cleanup?.();
  *
  * @example
  * // Open a specific workflow inline
@@ -41,9 +48,26 @@ export type ShowWorkflowBuilderProps = Options & {
  */
 export const showWorkflow = ({
   workflowId,
+  onDelete,
   ...options
 }: ShowWorkflowBuilderProps) => {
   assertInit("showWorkflowBuilder");
 
   setIframe(`/builder/${workflowId}/`, options, {});
+
+  if (onDelete) {
+    const abortController = new AbortController();
+
+    window.addEventListener(
+      "message",
+      (event: MessageEvent<{ event: string }>) => {
+        if (event.data?.event === PrismaticMessageEvent.WORKFLOW_DELETED) {
+          onDelete();
+        }
+      },
+      { signal: abortController.signal },
+    );
+
+    return () => abortController.abort();
+  }
 };

--- a/src/types/postMessage.ts
+++ b/src/types/postMessage.ts
@@ -67,6 +67,7 @@ export enum PrismaticMessageEvent {
   USER_CONFIGURATION_PAGE_LOADED = "USER_CONFIGURATION_PAGE_LOADED",
   USER_CONFIGURATION_OPENED = "USER_CONFIGURATION_OPENED",
   WORKFLOW_ENABLED = "WORKFLOW_ENABLED",
+  WORKFLOW_DELETED = "WORKFLOW_DELETED",
   WORKFLOW_DISABLED = "WORKFLOW_DISABLED",
 }
 
@@ -134,6 +135,10 @@ export type MessageData =
   | {
       data: WorkflowConfigurationData;
       event: PrismaticMessageEvent.WORKFLOW_ENABLED;
+    }
+  | {
+      data: WorkflowConfigurationData;
+      event: PrismaticMessageEvent.WORKFLOW_DELETED;
     }
   | {
       data: WorkflowConfigurationData;


### PR DESCRIPTION
Adds a `WORKFLOW_DELETED` event and an `onDelete` callback to `showWorkflow`

This should give embedding apps a way to eg: navigate away from the blank canvas after deleting a workflow rendered by `showWorkflow`