### PR TITLE
Add showTriggerSelectionOnLoad workflow builder screen configuration

### DIFF
--- a/src/lib/showWorkflow.ts
+++ b/src/lib/showWorkflow.ts
@@ -35,6 +35,16 @@ export type ShowWorkflowBuilderProps = Options & {
  * });
  *
  * @example
+ * // Open the workflow builder on the trigger selection screen
+ * prismatic.showWorkflow({
+ *   workflowId: "V29ya2Zsb3c6YTFiMmMz...",
+ *   selector: "#workflow-container",
+ *   screenConfiguration: {
+ *     workflowBuilder: { showTriggerSelectionOnLoad: true },
+ *   },
+ * });
+ *
+ * @example
  * // Open the workflow builder with the copilot panel already expanded
  * prismatic.showWorkflow({
  *   workflowId: "V29ya2Zsb3c6YTFiMmMz...",

--- a/src/types/screenConfiguration.ts
+++ b/src/types/screenConfiguration.ts
@@ -40,6 +40,14 @@ export interface CopilotConfiguration {
 
 export interface WorkflowBuilderConfiguration {
   copilot?: CopilotConfiguration;
+  /**
+   * When `true`, the builder opens with the trigger selection screen already
+   * displayed, letting your customer's users pick a trigger before working on
+   * the rest of the workflow.
+   *
+   * @default false
+   */
+  showTriggerSelectionOnLoad?: boolean;
 }
 
 export interface InitializingConfiguration {


### PR DESCRIPTION
Lets consumers open the workflow builder with the trigger selection screen already displayed via
screenConfiguration.workflowBuilder.showTriggerSelectionOnLoad.