### PR TITLE
chore: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <h1>@prismatic-io/embedded</h1>
 </div>
 
-`@prismatic-io/embedded` allows you to to embed Prismatic's [integration marketplace](https://prismatic.io/docs/instances/integration-marketplace/) and [workflow builder](https://prismatic.io/docs/embed/workflow-builder/workflow-builder/) within your web application, giving your customers the ability to manage integrations, instances, and connectors you've built in Prismatic.
+`@prismatic-io/embedded` allows you to embed Prismatic's [integration marketplace](https://prismatic.io/docs/instances/integration-marketplace/) and [workflow builder](https://prismatic.io/docs/embed/workflow-builder/workflow-builder/) within your web application, giving your customers the ability to manage integrations, instances, and connectors you've built in Prismatic.
 
 ## What is Prismatic?
 


### PR DESCRIPTION
This pull request removes a duplicated "to" in the README intro sentence.